### PR TITLE
refactor: replace Voyager with androidx.navigation3

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -96,6 +96,8 @@ kotlin {
 dependencies {
   implementation(projects.composeApp)
   implementation(libs.androidx.activity.compose)
+  implementation(libs.navigation3.runtime)
+  implementation(libs.navigation3.ui)
   debugImplementation(libs.compose.ui.tooling)
 }
 

--- a/androidApp/src/main/kotlin/com/seiko/keystoreviewer/MainActivity.kt
+++ b/androidApp/src/main/kotlin/com/seiko/keystoreviewer/MainActivity.kt
@@ -5,11 +5,15 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.runtime.CompositionLocalProvider
-import cafe.adriel.voyager.navigator.Navigator
-import cafe.adriel.voyager.transitions.SlideTransition
+import androidx.navigation3.runtime.NavKey
+import androidx.navigation3.runtime.entryProvider
+import androidx.navigation3.runtime.rememberNavBackStack
+import androidx.navigation3.ui.NavDisplay
+import data.model.SignSource
 import platform.ContentHandler
 import platform.LocalContentHandler
 import ui.screen.AppListScreen
+import ui.screen.SignatureDetailScreen
 import ui.theme.AppTheme
 
 class MainActivity : ComponentActivity() {
@@ -22,11 +26,31 @@ class MainActivity : ComponentActivity() {
         CompositionLocalProvider(
           LocalContentHandler provides contentHandler,
         ) {
-          Navigator(AppListScreen) { navigator ->
-            SlideTransition(navigator)
-          }
+          val backStack = rememberNavBackStack(AppList)
+          NavDisplay(
+            backStack = backStack,
+            entryProvider = entryProvider {
+              entry<AppList> {
+                AppListScreen(
+                  onItemClick = { signSource ->
+                    backStack.add(SignatureDetail(signSource))
+                  },
+                )
+              }
+              entry<SignatureDetail> { key ->
+                SignatureDetailScreen(
+                  signSource = key.signSource,
+                  onBack = { backStack.removeLastOrNull() },
+                )
+              }
+            },
+          )
         }
       }
     }
   }
 }
+
+data object AppList : NavKey
+
+data class SignatureDetail(val signSource: SignSource) : NavKey

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -25,9 +25,7 @@ kotlin {
       implementation(compose.materialIconsExtended)
       implementation(compose.components.resources)
       implementation(compose.components.uiToolingPreview)
-      api(libs.bundles.voyager)
       implementation(libs.kotlinx.io)
-      implementation(libs.molecule.runtime)
       implementation(libs.okio)
       implementation(libs.material.kolor)
     }
@@ -36,6 +34,7 @@ kotlin {
       implementation(libs.androidx.core.ktx)
       implementation(libs.androidx.activity.compose)
       implementation(libs.accompanist.permissions)
+      implementation(libs.molecule.runtime)
     }
     val desktopMain by getting
     desktopMain.dependencies {

--- a/composeApp/src/androidMain/kotlin/ui/component/MoleculeScreenModel.kt
+++ b/composeApp/src/androidMain/kotlin/ui/component/MoleculeScreenModel.kt
@@ -1,17 +1,20 @@
-package ui.component.voyager
+package ui.component
 
 import androidx.compose.runtime.Composable
 import app.cash.molecule.AndroidUiDispatcher
 import app.cash.molecule.RecompositionMode
 import app.cash.molecule.launchMolecule
-import cafe.adriel.voyager.core.model.ScreenModel
-import cafe.adriel.voyager.core.model.screenModelScope
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.StateFlow
 
-abstract class MoleculeScreenModel<T> : ScreenModel {
+abstract class MoleculeScreenModel<T> {
+
+  private val scope = CoroutineScope(SupervisorJob() + AndroidUiDispatcher.Main)
 
   val state: StateFlow<T> by lazy {
-    screenModelScope.launchMolecule(
+    scope.launchMolecule(
       mode = RecompositionMode.ContextClock,
       context = AndroidUiDispatcher.Main,
       body = { present() },
@@ -20,4 +23,8 @@ abstract class MoleculeScreenModel<T> : ScreenModel {
 
   @Composable
   protected abstract fun present(): T
+
+  fun dispose() {
+    scope.cancel()
+  }
 }

--- a/composeApp/src/androidMain/kotlin/ui/screen/AppListScreen.kt
+++ b/composeApp/src/androidMain/kotlin/ui/screen/AppListScreen.kt
@@ -44,10 +44,6 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import cafe.adriel.voyager.core.model.rememberScreenModel
-import cafe.adriel.voyager.core.screen.Screen
-import cafe.adriel.voyager.navigator.LocalNavigator
-import cafe.adriel.voyager.navigator.currentOrThrow
 import data.model.SignSource
 import data.model.UiAppInfo
 import kotlinx.coroutines.Dispatchers
@@ -60,87 +56,74 @@ import ui.widget.AppListItem
 import ui.widget.PermissionRequestContent
 import util.getFilePathFromUri
 
-object AppListScreen : Screen {
-  private fun readResolve(): Any = AppListScreen
+@Composable
+fun AppListScreen(onItemClick: (SignSource) -> Unit) {
+  val context = LocalContext.current
 
-  @Composable
-  override fun Content() {
-    val navigator = LocalNavigator.currentOrThrow
-    val context = LocalContext.current
+  val scope = rememberCoroutineScope()
 
-    val scope = rememberCoroutineScope()
-
-    val launcher = rememberLauncherForActivityResult(
-      remember { ActivityResultContracts.GetContent() },
-    ) { uri ->
-      if (uri != null) {
-        scope.launch {
-          val filePath = withContext(Dispatchers.IO) {
-            getFilePathFromUri(context, uri)
-          }
-          if (filePath != null) {
-            navigator.push(
-              SignatureDetailScreen(
-                signSource = SignSource.Apk(filePath),
-              ),
-            )
-          }
+  val launcher = rememberLauncherForActivityResult(
+    remember { ActivityResultContracts.GetContent() },
+  ) { uri ->
+    if (uri != null) {
+      scope.launch {
+        val filePath = withContext(Dispatchers.IO) {
+          getFilePathFromUri(context, uri)
+        }
+        if (filePath != null) {
+          onItemClick(SignSource.Apk(filePath))
         }
       }
     }
+  }
 
-    Scaffold(
-      floatingActionButton = {
-        FloatingActionButton(
-          onClick = {
-            // *.apk
-            launcher.launch("application/vnd.android.package-archive")
-          },
-        ) {
-          Icon(
-            rememberApkDocument(),
-            contentDescription = null,
-          )
+  Scaffold(
+    floatingActionButton = {
+      FloatingActionButton(
+        onClick = {
+          // *.apk
+          launcher.launch("application/vnd.android.package-archive")
+        },
+      ) {
+        Icon(
+          rememberApkDocument(),
+          contentDescription = null,
+        )
+      }
+    },
+  ) { innerPadding ->
+    PermissionRequestContent(
+      permissions = remember {
+        buildList {
+          if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            add(Manifest.permission.QUERY_ALL_PACKAGES)
+          }
         }
       },
-    ) { innerPadding ->
-      PermissionRequestContent(
-        permissions = remember {
-          buildList {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-              add(Manifest.permission.QUERY_ALL_PACKAGES)
+      modifier = Modifier
+        .padding(innerPadding)
+        .fillMaxSize(),
+      label = "The application needs to access the program list, please grant permission to read the application list.",
+    ) {
+      val state by remember {
+        AppListScreenModel(context.applicationContext)
+      }.state.collectAsState()
+      AppListContent(
+        innerPadding = innerPadding,
+        state = state,
+        context = context,
+        onEvent = { event ->
+          when (event) {
+            is AppListScreenEvent.OnItemClick -> {
+              onItemClick(SignSource.PackageName(event.packageName))
+            }
+
+            else -> {
+              state.eventSink(event)
             }
           }
         },
-        modifier = Modifier
-          .padding(innerPadding)
-          .fillMaxSize(),
-        label = "The application needs to access the program list, please grant permission to read the application list.",
-      ) {
-        val state by rememberScreenModel {
-          AppListScreenModel(context.applicationContext)
-        }.state.collectAsState()
-        AppListContent(
-          innerPadding = innerPadding,
-          state = state,
-          context = context,
-          onEvent = { event ->
-            when (event) {
-              is AppListScreenEvent.OnItemClick -> {
-                navigator.push(
-                  SignatureDetailScreen(
-                    signSource = SignSource.PackageName(event.packageName),
-                  ),
-                )
-              }
-
-              else -> {
-                state.eventSink(event)
-              }
-            }
-          },
-        )
-      }
+      )
     }
   }
 }

--- a/composeApp/src/androidMain/kotlin/ui/screen/AppListScreenModel.kt
+++ b/composeApp/src/androidMain/kotlin/ui/screen/AppListScreenModel.kt
@@ -17,8 +17,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.withContext
+import ui.component.MoleculeScreenModel
 import ui.component.state.UiState
-import ui.component.voyager.MoleculeScreenModel
 import util.getSystemAppInfos
 import util.getUserInstalledAppInfos
 

--- a/composeApp/src/commonMain/kotlin/ui/screen/SignatureDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/ui/screen/SignatureDetailScreen.kt
@@ -40,9 +40,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import cafe.adriel.voyager.core.screen.Screen
-import cafe.adriel.voyager.navigator.LocalNavigator
-import cafe.adriel.voyager.navigator.currentOrThrow
 import data.model.AppSignature
 import data.model.SignSource
 import data.model.UiAppInfo
@@ -62,26 +59,27 @@ import java.math.BigInteger
 import java.security.cert.CertificateFactory
 import java.security.interfaces.RSAPublicKey
 
-data class SignatureDetailScreen(
-  private val signSource: SignSource,
-) : Screen {
-  @Composable
-  override fun Content() {
-    val navigator = LocalNavigator.currentOrThrow
-    val contentHandler = LocalContentHandler.current
-    SignatureDetailScreen(
-      onBack = {
-        navigator.pop()
-      },
-      signSource = signSource,
-      onShareContentClick = { content ->
-        contentHandler.shareContent(content)
-      },
-      onCopyContentClick = { content, label ->
-        contentHandler.copyToClipboard(content, label)
-      },
-    )
-  }
+@OptIn(
+  ExperimentalMaterial3Api::class,
+  ExperimentalFoundationApi::class,
+  ExperimentalStdlibApi::class,
+)
+@Composable
+fun SignatureDetailScreen(
+  signSource: SignSource,
+  onBack: () -> Unit,
+) {
+  val contentHandler = LocalContentHandler.current
+  SignatureDetailScreen(
+    onBack = onBack,
+    signSource = signSource,
+    onShareContentClick = { content ->
+      contentHandler.shareContent(content)
+    },
+    onCopyContentClick = { content, label ->
+      contentHandler.copyToClipboard(content, label)
+    },
+  )
 }
 
 @OptIn(

--- a/composeApp/src/desktopMain/kotlin/Main.kt
+++ b/composeApp/src/desktopMain/kotlin/Main.kt
@@ -1,8 +1,10 @@
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.application
-import cafe.adriel.voyager.navigator.Navigator
-import cafe.adriel.voyager.transitions.SlideTransition
-import ui.screen.DropUploadScreen
+import data.model.SignSource
+import ui.screen.DropUploadContent
+import ui.screen.SignatureDetailScreen
 import ui.theme.AppTheme
 
 fun main() = application {
@@ -11,9 +13,28 @@ fun main() = application {
     title = "KeyStoreViewer",
   ) {
     AppTheme {
-      Navigator(DropUploadScreen) { navigator ->
-        SlideTransition(navigator)
+      val stack = remember { mutableStateListOf<DesktopPage>(DesktopPage.Upload) }
+
+      when (val page = stack.last()) {
+        DesktopPage.Upload -> DropUploadContent(
+          onNavigateToDetail = { path ->
+            stack.add(DesktopPage.SignatureDetail(SignSource.Apk(path)))
+          },
+        )
+
+        is DesktopPage.SignatureDetail -> SignatureDetailScreen(
+          signSource = page.signSource,
+          onBack = {
+            stack.removeAt(stack.lastIndex)
+          },
+        )
       }
     }
   }
+}
+
+sealed interface DesktopPage {
+  data object Upload : DesktopPage
+
+  data class SignatureDetail(val signSource: SignSource) : DesktopPage
 }

--- a/composeApp/src/desktopMain/kotlin/ui/screen/DropUploadScreen.kt
+++ b/composeApp/src/desktopMain/kotlin/ui/screen/DropUploadScreen.kt
@@ -27,34 +27,12 @@ import androidx.compose.ui.draganddrop.DragData
 import androidx.compose.ui.draganddrop.dragData
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
-import cafe.adriel.voyager.core.screen.Screen
-import cafe.adriel.voyager.navigator.LocalNavigator
-import cafe.adriel.voyager.navigator.currentOrThrow
 import data.model.SignSource
 import kotlinx.coroutines.launch
 import java.net.URI
 import kotlin.io.path.exists
 import kotlin.io.path.fileSize
 import kotlin.io.path.toPath
-
-object DropUploadScreen : Screen {
-
-  private fun readResolve(): Any = DropUploadScreen
-
-  @Composable
-  override fun Content() {
-    val navigator = LocalNavigator.currentOrThrow
-    DropUploadContent(
-      onNavigateToDetail = {
-        navigator.push(
-          SignatureDetailScreen(
-            SignSource.Apk(it),
-          ),
-        )
-      },
-    )
-  }
-}
 
 @OptIn(ExperimentalFoundationApi::class, ExperimentalComposeUiApi::class)
 @Composable

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ compose-plugin = "1.12.0"
 kotlin = "2.4.10"
 spotless = "8.10.2"
 ktlint = "1.8.0"
-voyager = "2.2.21-1.10.3"
+navigation3 = "1.2.0-beta01"
 
 [libraries]
 junit = { group = "junit", name = "junit", version = "4.13.2" }
@@ -21,21 +21,13 @@ kotlinx-io = { module = "org.jetbrains.kotlinx:kotlinx-io-core", version = "0.9.
 
 compose-ui-tooling = { module = "org.jetbrains.compose.ui:ui-tooling", version.ref = "compose-plugin" }
 
-voyager-navigator = { module = "cafe.adriel.voyager:voyager-navigator", version.ref = "voyager" }
-voyager-screenModel = { module = "cafe.adriel.voyager:voyager-screenmodel", version.ref = "voyager" }
-voyager-transitions = { module = "cafe.adriel.voyager:voyager-transitions", version.ref = "voyager" }
+navigation3-runtime = { module = "androidx.navigation3:navigation3-runtime", version.ref = "navigation3" }
+navigation3-ui = { module = "androidx.navigation3:navigation3-ui", version.ref = "navigation3" }
 
 molecule-runtime = { module = "app.cash.molecule:molecule-runtime", version = "2.2.0" }
 accompanist-permissions = { module = "com.google.accompanist:accompanist-permissions", version = "0.37.3" }
 okio = { module = "com.squareup.okio:okio", version = "3.18.2" }
 material-kolor = { module = "com.materialkolor:material-kolor", version = "5.0.1" }
-
-[bundles]
-voyager = [
-    "voyager-navigator",
-    "voyager-screenModel",
-    "voyager-transitions",
-]
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## 变更

移除 Voyager，Android 端迁移到 **Jetpack Navigation3**（`androidx.navigation3:1.2.0-beta01`），库层屏幕与导航完全解耦：

### 结构调整
- **依赖**：删除 voyager 三件套 + bundle；新增 `navigation3-runtime` / `navigation3-ui`（仅 androidApp）
- **库层（composeApp）**：`AppListScreen`、`SignatureDetailScreen`、`DropUploadScreen` 从 Voyager `Screen` 改为普通 Composable，导航通过回调（`onItemClick` / `onBack` / `onNavigateToDetail`）
- `MoleculeScreenModel` 移到 `ui.component`，不再继承 `ScreenModel`，自带 `CoroutineScope`（molecule 依赖移到 androidMain）
- **Android 入口（androidApp）**：`NavDisplay` + `rememberNavBackStack` + `entryProvider` DSL，两个路由 `AppList` / `SignatureDetail(signSource)`
- **桌面端**：Navigation3 非 Android 目标只有 stubs（运行时会抛异常），因此用 `mutableStateList` 实现的极简返回栈（本应用只有两层页面，够用）

## 已知取舍
- Nav3 1.2.0-beta01 的系统返回/预测性返回由库内建处理；桌面端返回靠详情页左上角返回键
- `SignatureDetail(signSource)` key 未做序列化 saved-state（nav3 支持 @Serializable key，后续可加）

## 验证
- ✅ `androidApp:assembleDebug / assembleRelease`（签名 CC:FF:AA:DD 上传密钥）
- ✅ `composeApp:compileKotlinDesktop`
- ✅ `spotlessCheck`
- ✅ 全项目无 voyager 残留

> 基于分支 `chore/upgrade-dependencies`（PR #5），请先合并 #5 再合并本 PR。