### PR TITLE
feat: motion3 predictive-back transitions for navigation3

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -5,6 +5,7 @@ import java.util.Properties
 plugins {
   alias(libs.plugins.androidApplication)
   id("org.jetbrains.kotlin.plugin.compose")
+  id("org.jetbrains.kotlin.plugin.serialization")
 }
 
 android {

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -98,6 +98,7 @@ dependencies {
   implementation(libs.androidx.activity.compose)
   implementation(libs.navigation3.runtime)
   implementation(libs.navigation3.ui)
+  implementation(libs.androidx.navigationevent.compose)
   debugImplementation(libs.compose.ui.tooling)
 }
 

--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
 
     <application
         android:allowBackup="true"
+        android:enableOnBackInvokedCallback="true"
         android:icon="@mipmap/ic_logo"
         android:label="@string/app_name"
         android:supportsRtl="true"

--- a/androidApp/src/main/kotlin/com/seiko/keystoreviewer/MainActivity.kt
+++ b/androidApp/src/main/kotlin/com/seiko/keystoreviewer/MainActivity.kt
@@ -4,11 +4,24 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.entryProvider
+import androidx.navigation3.runtime.rememberDecoratedNavEntries
 import androidx.navigation3.runtime.rememberNavBackStack
+import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
+import androidx.navigation3.scene.SinglePaneSceneStrategy
+import androidx.navigation3.scene.rememberNavigationEventState
+import androidx.navigation3.scene.rememberSceneState
 import androidx.navigation3.ui.NavDisplay
+import com.seiko.keystoreviewer.ui.motion3.Motion3BackHandler
+import com.seiko.keystoreviewer.ui.motion3.motion3Metadata
+import com.seiko.keystoreviewer.ui.motion3.motion3PopTransitionSpec
+import com.seiko.keystoreviewer.ui.motion3.motion3PredictivePopTransitionSpec
+import com.seiko.keystoreviewer.ui.motion3.motion3TransitionSpec
+import com.seiko.keystoreviewer.ui.motion3.rememberMotion3
+import com.seiko.keystoreviewer.ui.motion3.rememberMotion3SceneDecoratorStrategy
 import data.model.SignSource
 import platform.ContentHandler
 import platform.LocalContentHandler
@@ -26,25 +39,7 @@ class MainActivity : ComponentActivity() {
         CompositionLocalProvider(
           LocalContentHandler provides contentHandler,
         ) {
-          val backStack = rememberNavBackStack(AppList)
-          NavDisplay(
-            backStack = backStack,
-            entryProvider = entryProvider {
-              entry<AppList> {
-                AppListScreen(
-                  onItemClick = { signSource ->
-                    backStack.add(SignatureDetail(signSource))
-                  },
-                )
-              }
-              entry<SignatureDetail> { key ->
-                SignatureDetailScreen(
-                  signSource = key.signSource,
-                  onBack = { backStack.removeLastOrNull() },
-                )
-              }
-            },
-          )
+          KeyStoreViewerApp()
         }
       }
     }
@@ -54,3 +49,59 @@ class MainActivity : ComponentActivity() {
 data object AppList : NavKey
 
 data class SignatureDetail(val signSource: SignSource) : NavKey
+
+@Composable
+private fun KeyStoreViewerApp() {
+  val backStack = rememberNavBackStack(AppList)
+  val onBack: () -> Unit = {
+    if (backStack.size > 1) {
+      backStack.removeLastOrNull()
+    }
+  }
+
+  val motion = rememberMotion3()
+  val motionSceneDecorator = rememberMotion3SceneDecoratorStrategy<NavKey>(motion)
+  val entries = rememberDecoratedNavEntries(
+    backStack = backStack,
+    entryDecorators = listOf(rememberSaveableStateHolderNavEntryDecorator()),
+    entryProvider = entryProvider {
+      entry<AppList> {
+        AppListScreen(
+          onItemClick = { signSource ->
+            backStack.add(SignatureDetail(signSource))
+          },
+        )
+      }
+      entry<SignatureDetail>(
+        metadata = motion3Metadata(),
+      ) { key ->
+        SignatureDetailScreen(
+          signSource = key.signSource,
+          onBack = onBack,
+        )
+      }
+    },
+  )
+  val sceneState = rememberSceneState(
+    entries = entries,
+    sceneStrategies = listOf(SinglePaneSceneStrategy()),
+    sceneDecoratorStrategies = listOf(motionSceneDecorator),
+    onBack = onBack,
+  )
+  val navigationEventState = rememberNavigationEventState(sceneState)
+
+  Motion3BackHandler(
+    sceneState = sceneState,
+    navigationEventState = navigationEventState,
+    motion = motion,
+    onBackCompleted = onBack,
+  )
+
+  NavDisplay(
+    sceneState = sceneState,
+    navigationEventState = navigationEventState,
+    transitionSpec = { motion3TransitionSpec() },
+    popTransitionSpec = { motion3PopTransitionSpec() },
+    predictivePopTransitionSpec = { motion3PredictivePopTransitionSpec() },
+  )
+}

--- a/androidApp/src/main/kotlin/com/seiko/keystoreviewer/MainActivity.kt
+++ b/androidApp/src/main/kotlin/com/seiko/keystoreviewer/MainActivity.kt
@@ -23,6 +23,7 @@ import com.seiko.keystoreviewer.ui.motion3.motion3TransitionSpec
 import com.seiko.keystoreviewer.ui.motion3.rememberMotion3
 import com.seiko.keystoreviewer.ui.motion3.rememberMotion3SceneDecoratorStrategy
 import data.model.SignSource
+import kotlinx.serialization.Serializable
 import platform.ContentHandler
 import platform.LocalContentHandler
 import ui.screen.AppListScreen
@@ -46,8 +47,10 @@ class MainActivity : ComponentActivity() {
   }
 }
 
+@Serializable
 data object AppList : NavKey
 
+@Serializable
 data class SignatureDetail(val signSource: SignSource) : NavKey
 
 @Composable

--- a/androidApp/src/main/kotlin/com/seiko/keystoreviewer/ui/motion3/Motion3.kt
+++ b/androidApp/src/main/kotlin/com/seiko/keystoreviewer/ui/motion3/Motion3.kt
@@ -1,0 +1,440 @@
+package com.seiko.keystoreviewer.ui.motion3
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.spring
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.navigationevent.NavigationEvent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import kotlin.math.abs
+import kotlin.math.max
+import kotlin.math.sign
+
+/** Creates and remembers a [Motion3] driven by the current composition scope. */
+@Composable
+fun rememberMotion3(spec: Motion3Spec = Motion3Spec()): Motion3 {
+  val scope = rememberCoroutineScope()
+  return remember(scope, spec) { Motion3(scope, spec) }
+}
+
+/**
+ * State machine behind the activity-style transition.
+ *
+ * A gesture walks through [Phase.GESTURE] while the finger is down; on lift it
+ * either springs to [Phase.CANCEL] (surface returns) or [Phase.COMPLETE]
+ * (surface commits and the navigation pops). Both settle springs start with the
+ * velocity the finger had at release so the motion never restarts from zero.
+ */
+@Stable
+class Motion3 internal constructor(
+  private val scope: CoroutineScope,
+  val spec: Motion3Spec,
+) {
+  internal var phase by mutableStateOf(Phase.IDLE)
+    private set
+  internal var closingKey by mutableStateOf<Any?>(null)
+    private set
+  internal var enteringKey by mutableStateOf<Any?>(null)
+    private set
+  internal var lastProgress: Float = 0f
+    private set
+  private var committedStartProgress: Float = 0f
+  private var swipeEdge: Int = NavigationEvent.EDGE_LEFT
+  private var gestureProgressProvider: () -> Float = { lastProgress }
+  private var maxScrimAlpha: Float = spec.lightScrimAlpha
+
+  // Bounded so a fast flick cannot overshoot past the end of the transition and
+  // spend frames springing back to a position the transform would clamp anyway.
+  // Hitting the bound ends the animation, which is exactly the desired
+  // "flick finishes sooner" behaviour.
+  private val cancelProgress = Animatable(0f).apply { updateBounds(0f, 1f) }
+  private val completionProgress = Animatable(0f).apply { updateBounds(0f, 1f) }
+
+  /** Touch position the gesture started from; the y-shift is measured against it. */
+  private var initialTouchY: Float = Float.NaN
+  private var currentTouchY: Float = Float.NaN
+  private var committedTouchY: Float = Float.NaN
+
+  /**
+   * Rolling velocity of the eased gesture progress, in progress-per-second,
+   * sampled from the navigation event's frame timestamps so the settle spring
+   * can pick the gesture up where the finger left it.
+   */
+  private var progressVelocity: Float = 0f
+  private var lastSampleProgress: Float = 0f
+  private var lastSampleTimeMillis: Long = 0L
+
+  internal fun updateRuntime(
+    gestureProgressProvider: () -> Float,
+    maxScrimAlpha: Float,
+  ) {
+    this.gestureProgressProvider = gestureProgressProvider
+    this.maxScrimAlpha = maxScrimAlpha
+  }
+
+  internal fun startGesture(
+    closingKey: Any,
+    enteringKey: Any?,
+    swipeEdge: Int,
+    touchY: Float,
+  ) {
+    this.swipeEdge = swipeEdge
+    if (
+      phase == Phase.GESTURE &&
+      this.closingKey == closingKey &&
+      this.enteringKey == enteringKey
+    ) {
+      return
+    }
+    this.closingKey = closingKey
+    this.enteringKey = enteringKey
+    lastProgress = 0f
+    committedStartProgress = 0f
+    initialTouchY = touchY
+    currentTouchY = touchY
+    committedTouchY = touchY
+    progressVelocity = 0f
+    lastSampleProgress = 0f
+    lastSampleTimeMillis = 0L
+    phase = Phase.GESTURE
+  }
+
+  internal fun updateGestureProgress(
+    progress: Float,
+    swipeEdge: Int,
+    touchY: Float,
+    frameTimeMillis: Long,
+  ): Float {
+    this.swipeEdge = swipeEdge
+    val easedProgress = easedGestureProgress(progress)
+    if (initialTouchY.isNaN()) initialTouchY = touchY
+    currentTouchY = touchY
+    sampleVelocity(easedProgress, frameTimeMillis)
+    lastProgress = easedProgress
+    return easedProgress
+  }
+
+  /**
+   * Records progress-per-second between two distinct event frames. Same-frame
+   * reads are ignored: the provider is polled once per placement pass, which
+   * can happen several times per frame, and a zero time delta would otherwise
+   * wipe the velocity right before the finger lifts.
+   */
+  private fun sampleVelocity(easedProgress: Float, frameTimeMillis: Long) {
+    if (lastSampleTimeMillis == 0L || frameTimeMillis <= lastSampleTimeMillis) {
+      if (lastSampleTimeMillis == 0L) {
+        lastSampleTimeMillis = frameTimeMillis
+        lastSampleProgress = easedProgress
+      }
+      return
+    }
+    val elapsedSeconds = (frameTimeMillis - lastSampleTimeMillis) / 1000f
+    progressVelocity = (easedProgress - lastSampleProgress) / elapsedSeconds
+    lastSampleProgress = easedProgress
+    lastSampleTimeMillis = frameTimeMillis
+  }
+
+  internal fun cancel() {
+    if (phase == Phase.IDLE) return
+    scope.launch {
+      val startProgress = lastProgress.coerceIn(0f, 1f)
+      // Only a finger still travelling backwards should speed the cancel up;
+      // carrying a forward velocity over would make the surface lurch further
+      // out before returning.
+      val handoffVelocity = progressVelocity.coerceAtMost(0f)
+      phase = Phase.CANCEL
+      cancelProgress.snapTo(startProgress)
+      cancelProgress.animateTo(
+        targetValue = 0f,
+        animationSpec = settleSpring(),
+        initialVelocity = handoffVelocity,
+      )
+      clear()
+    }
+  }
+
+  internal fun complete() {
+    if (phase == Phase.IDLE) return
+    val startProgress = lastProgress.coerceIn(0f, 1f)
+    // Mirror of cancel(): a finger travelling backwards at release must not
+    // push the committed animation forwards.
+    val handoffVelocity = progressVelocity.coerceAtLeast(0f)
+    phase = Phase.COMPLETE
+    committedStartProgress = startProgress
+    committedTouchY = currentTouchY
+    scope.launch {
+      completionProgress.snapTo(0f)
+      completionProgress.animateTo(
+        targetValue = 1f,
+        animationSpec = settleSpring(),
+        // The gesture measures progress towards the commit point while this
+        // animation measures progress away from it, so the remainder of the
+        // gesture sets the initial scale.
+        initialVelocity = handoffVelocity / max(1f - startProgress, MIN_VELOCITY_SCALE),
+      )
+      clear()
+    }
+  }
+
+  private fun settleSpring() = spring<Float>(
+    dampingRatio = spec.settleDampingRatio,
+    stiffness = spec.settleStiffness,
+    visibilityThreshold = SETTLE_VISIBILITY_THRESHOLD,
+  )
+
+  private fun clear() {
+    phase = Phase.IDLE
+    closingKey = null
+    enteringKey = null
+    lastProgress = 0f
+    committedStartProgress = 0f
+    swipeEdge = NavigationEvent.EDGE_LEFT
+    initialTouchY = Float.NaN
+    currentTouchY = Float.NaN
+    committedTouchY = Float.NaN
+    progressVelocity = 0f
+    lastSampleProgress = 0f
+    lastSampleTimeMillis = 0L
+  }
+
+  internal fun roleFor(sceneKey: Any): SceneRole {
+    if (phase == Phase.IDLE) return SceneRole.NONE
+    return when (sceneKey) {
+      closingKey -> SceneRole.CLOSING
+      enteringKey -> SceneRole.ENTERING
+      else -> SceneRole.NONE
+    }
+  }
+
+  internal fun transformFor(
+    role: SceneRole,
+    widthPx: Float,
+    heightPx: Float,
+    enteringOffsetPx: Float,
+    marginPx: Float,
+  ): Motion3Transform = when (phase) {
+    Phase.IDLE -> Motion3Transform()
+
+    Phase.GESTURE,
+    Phase.CANCEL,
+    -> preCommitTransform(
+      role = role,
+      progress = preCommitProgress(),
+      widthPx = widthPx,
+      heightPx = heightPx,
+      enteringOffsetPx = enteringOffsetPx,
+      marginPx = marginPx,
+      swipeEdge = swipeEdge,
+      touchY = currentTouchY,
+    )
+
+    Phase.COMPLETE -> postCommitTransform(
+      role = role,
+      startProgress = committedStartProgress.coerceIn(0f, 1f),
+      completionProgress = completionProgress.value.coerceIn(0f, 1f),
+      widthPx = widthPx,
+      heightPx = heightPx,
+      enteringOffsetPx = enteringOffsetPx,
+      marginPx = marginPx,
+      swipeEdge = swipeEdge,
+    )
+  }
+
+  internal fun scrimAlpha(): Float {
+    val scrimProgress = when (phase) {
+      Phase.IDLE -> 0f
+
+      Phase.GESTURE,
+      Phase.CANCEL,
+      -> preCommitProgress()
+
+      Phase.COMPLETE -> 1f - completionProgress.value.coerceIn(0f, 1f)
+    }
+    return maxScrimAlpha * scrimProgress.coerceIn(0f, 1f)
+  }
+
+  private fun preCommitProgress(): Float = when (phase) {
+    Phase.GESTURE -> gestureProgressProvider()
+    Phase.CANCEL -> cancelProgress.value
+    Phase.COMPLETE -> committedStartProgress
+    Phase.IDLE -> 0f
+  }.coerceIn(0f, 1f)
+
+  /**
+   * Vertical offset the surface takes on top of being centred, following the
+   * finger. The shift is capped so the surface never crosses the margin, and the
+   * travelled distance is mapped onto that cap through a decelerating curve;
+   * scaled by progress so the surface does not jump as soon as the gesture is
+   * recognised.
+   */
+  private fun gestureYShift(
+    heightPx: Float,
+    marginPx: Float,
+    progress: Float,
+    touchY: Float,
+  ): Float {
+    if (!spec.followTouchVertically) return 0f
+    if (touchY.isNaN() || initialTouchY.isNaN()) return 0f
+    val maxYShift = heightPx * spec.maxYShiftFraction - marginPx
+    if (maxYShift <= 0f) return 0f
+    val rawDelta = touchY - initialTouchY
+    val ratio = (abs(rawDelta) / maxYShift).coerceIn(0f, 1f)
+    return spec.verticalEasing.transform(ratio) * maxYShift * sign(rawDelta) * progress
+  }
+
+  private fun preCommitTransform(
+    role: SceneRole,
+    progress: Float,
+    widthPx: Float,
+    heightPx: Float,
+    enteringOffsetPx: Float,
+    marginPx: Float,
+    swipeEdge: Int,
+    touchY: Float,
+  ): Motion3Transform {
+    if (role == SceneRole.NONE) return Motion3Transform()
+    val scale = lerp(1f, spec.maxScale, progress)
+    val translationX = when (role) {
+      SceneRole.CLOSING -> lerp(
+        start = 0f,
+        stop = closingTargetTranslationX(widthPx, marginPx, swipeEdge),
+        fraction = progress,
+      )
+
+      SceneRole.ENTERING -> lerp(
+        start = -enteringOffsetPx,
+        stop = -enteringOffsetPx + centeredScaleInset(widthPx),
+        fraction = progress,
+      )
+
+      SceneRole.NONE -> 0f
+    }
+    val centredTranslationY = lerp(
+      start = 0f,
+      stop = centeredScaleInset(heightPx),
+      fraction = progress,
+    )
+    // Only the closing surface tracks the finger; the entering surface stays
+    // put underneath, the way the platform animates a returning task.
+    val yShift = if (role == SceneRole.CLOSING) {
+      gestureYShift(heightPx, marginPx, progress, touchY)
+    } else {
+      0f
+    }
+    return Motion3Transform(
+      translationX = translationX,
+      translationY = centredTranslationY + yShift,
+      scale = scale,
+      clip = progress > 0.001f,
+    )
+  }
+
+  private fun postCommitTransform(
+    role: SceneRole,
+    startProgress: Float,
+    completionProgress: Float,
+    widthPx: Float,
+    heightPx: Float,
+    enteringOffsetPx: Float,
+    marginPx: Float,
+    swipeEdge: Int,
+  ): Motion3Transform {
+    if (role == SceneRole.NONE) return Motion3Transform()
+    val startScale = lerp(1f, spec.maxScale, startProgress)
+    val startTranslationX = when (role) {
+      SceneRole.CLOSING -> lerp(
+        start = 0f,
+        stop = closingTargetTranslationX(widthPx, marginPx, swipeEdge),
+        fraction = startProgress,
+      )
+
+      SceneRole.ENTERING -> lerp(
+        start = -enteringOffsetPx,
+        stop = -enteringOffsetPx + centeredScaleInset(widthPx),
+        fraction = startProgress,
+      )
+
+      SceneRole.NONE -> 0f
+    }
+    // Hand the settle animation the exact vertical offset the finger left the
+    // surface at, so the committed animation continues from where the gesture
+    // stopped instead of snapping back to centre first.
+    val startYShift = if (role == SceneRole.CLOSING) {
+      gestureYShift(heightPx, marginPx, startProgress, committedTouchY)
+    } else {
+      0f
+    }
+    val startTranslationY = lerp(
+      start = 0f,
+      stop = centeredScaleInset(heightPx),
+      fraction = startProgress,
+    ) + startYShift
+    val targetTranslationX = when (role) {
+      SceneRole.CLOSING -> startTranslationX + enteringOffsetPx
+      SceneRole.ENTERING -> 0f
+      SceneRole.NONE -> 0f
+    }
+    val alpha = when (role) {
+      SceneRole.CLOSING -> max(1f - completionProgress * 2f, 0f)
+
+      SceneRole.ENTERING,
+      SceneRole.NONE,
+      -> 1f
+    }
+    return Motion3Transform(
+      translationX = lerp(startTranslationX, targetTranslationX, completionProgress),
+      translationY = lerp(startTranslationY, 0f, completionProgress),
+      scale = lerp(startScale, 1f, completionProgress),
+      alpha = alpha,
+      clip = completionProgress < 1f,
+    )
+  }
+
+  private fun closingTargetTranslationX(
+    widthPx: Float,
+    marginPx: Float,
+    swipeEdge: Int,
+  ): Float = if (swipeEdge == NavigationEvent.EDGE_RIGHT) {
+    centeredScaleInset(widthPx)
+  } else {
+    widthPx * (1f - spec.maxScale) - marginPx
+  }
+
+  private fun centeredScaleInset(widthPx: Float): Float = widthPx * (1f - spec.maxScale) / 2f
+
+  private fun easedGestureProgress(progress: Float): Float = spec.gestureEasing.transform(progress.coerceIn(0f, 1f))
+
+  private companion object {
+    const val SETTLE_VISIBILITY_THRESHOLD = 0.001f
+    const val MIN_VELOCITY_SCALE = 0.05f
+  }
+}
+
+internal enum class Phase {
+  IDLE,
+  GESTURE,
+  CANCEL,
+  COMPLETE,
+}
+
+internal enum class SceneRole {
+  NONE,
+  CLOSING,
+  ENTERING,
+}
+
+internal data class Motion3Transform(
+  val translationX: Float = 0f,
+  val translationY: Float = 0f,
+  val scale: Float = 1f,
+  val alpha: Float = 1f,
+  val clip: Boolean = false,
+)
+
+private fun lerp(start: Float, stop: Float, fraction: Float): Float = start + (stop - start) * fraction.coerceIn(0f, 1f)

--- a/androidApp/src/main/kotlin/com/seiko/keystoreviewer/ui/motion3/Motion3BackHandler.kt
+++ b/androidApp/src/main/kotlin/com/seiko/keystoreviewer/ui/motion3/Motion3BackHandler.kt
@@ -1,0 +1,119 @@
+package com.seiko.keystoreviewer.ui.motion3
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.snapshotFlow
+import androidx.navigation3.runtime.get
+import androidx.navigation3.scene.SceneInfo
+import androidx.navigation3.scene.SceneState
+import androidx.navigationevent.NavigationEvent
+import androidx.navigationevent.NavigationEventTransitionState.InProgress
+import androidx.navigationevent.compose.NavigationBackHandler
+import androidx.navigationevent.compose.NavigationEventState
+
+/**
+ * Bridges the system predictive-back gesture into [Motion3].
+ *
+ * While the gesture is in progress the closing surface follows the finger; on
+ * lift the motion either springs back ([onBackCancelled]) or commits
+ * ([onBackCompleted], invoked once per popped entry). Scenes whose destination
+ * did not opt in through [motion3Metadata] are ignored.
+ */
+@Composable
+fun <T : Any> Motion3BackHandler(
+  sceneState: SceneState<T>,
+  navigationEventState: NavigationEventState<SceneInfo<T>>,
+  motion: Motion3,
+  maxScrimAlpha: Float = motion.spec.lightScrimAlpha,
+  onBackCancelled: () -> Unit = {},
+  onBackCompleted: () -> Unit,
+) {
+  val currentScene = sceneState.currentScene
+  val previousScene = sceneState.previousScenes.lastOrNull()
+  val motionEnabled = currentScene.metadata[Motion3MetadataKey] == true
+  val predictiveBackEnabled = motionEnabled && previousScene != null
+
+  SideEffect {
+    motion.updateRuntime(
+      gestureProgressProvider = {
+        val transition = navigationEventState.transitionState
+        if (transition is InProgress && predictiveBackEnabled) {
+          motion.updateGestureProgress(
+            progress = transition.latestEvent.progress,
+            swipeEdge = transition.latestEvent.swipeEdge,
+            touchY = transition.latestEvent.touchY,
+            frameTimeMillis = transition.latestEvent.frameTimeMillis,
+          )
+        } else {
+          motion.lastProgress
+        }
+      },
+      maxScrimAlpha = maxScrimAlpha,
+    )
+  }
+
+  LaunchedEffect(
+    navigationEventState,
+    predictiveBackEnabled,
+    motionEnabled,
+    currentScene.key,
+    previousScene?.key,
+  ) {
+    snapshotFlow {
+      val transition = navigationEventState.transitionState
+      if (transition is InProgress && predictiveBackEnabled) {
+        GestureSnapshot(
+          inProgress = true,
+          swipeEdge = transition.latestEvent.swipeEdge,
+          touchY = transition.latestEvent.touchY,
+        )
+      } else {
+        GestureSnapshot.Idle
+      }
+    }.collect { snapshot ->
+      if (!snapshot.inProgress) return@collect
+      motion.startGesture(
+        closingKey = currentScene.key,
+        enteringKey = previousScene?.key,
+        swipeEdge = snapshot.swipeEdge,
+        touchY = snapshot.touchY,
+      )
+    }
+  }
+
+  NavigationBackHandler(
+    state = navigationEventState,
+    isBackEnabled = currentScene.previousEntries.isNotEmpty(),
+    onBackCancelled = {
+      if (motionEnabled) {
+        motion.cancel()
+      }
+      onBackCancelled()
+    },
+    onBackCompleted = {
+      if (motionEnabled) {
+        motion.complete()
+      }
+      val popCount = (sceneState.entries.size - currentScene.previousEntries.size)
+        .coerceAtLeast(0)
+      repeat(popCount) {
+        onBackCompleted()
+      }
+    },
+  )
+}
+
+private data class GestureSnapshot(
+  val inProgress: Boolean,
+  @param:NavigationEvent.SwipeEdge val swipeEdge: Int,
+  val touchY: Float,
+) {
+  companion object {
+    val Idle = GestureSnapshot(
+      inProgress = false,
+      swipeEdge = NavigationEvent.EDGE_LEFT,
+      touchY = Float.NaN,
+    )
+  }
+}

--- a/androidApp/src/main/kotlin/com/seiko/keystoreviewer/ui/motion3/Motion3Metadata.kt
+++ b/androidApp/src/main/kotlin/com/seiko/keystoreviewer/ui/motion3/Motion3Metadata.kt
@@ -1,0 +1,22 @@
+package com.seiko.keystoreviewer.ui.motion3
+
+import androidx.navigation3.runtime.NavMetadataKey
+import androidx.navigation3.runtime.metadata
+
+/**
+ * Marks a destination as participating in the activity-style motion transition.
+ *
+ * Attach it to a destination through [motion3Metadata]; scenes without this
+ * metadata keep the plain [NavDisplay][androidx.navigation3.ui.NavDisplay]
+ * transitions and never take part in the predictive-back motion.
+ */
+data object Motion3MetadataKey : NavMetadataKey<Boolean>
+
+/**
+ * Builds the metadata map that enables the motion3 transition for a destination.
+ *
+ * @param enabled pass `false` to explicitly opt a destination out.
+ */
+fun motion3Metadata(enabled: Boolean = true): Map<String, Any> = metadata {
+  put(Motion3MetadataKey, enabled)
+}

--- a/androidApp/src/main/kotlin/com/seiko/keystoreviewer/ui/motion3/Motion3SceneDecorator.kt
+++ b/androidApp/src/main/kotlin/com/seiko/keystoreviewer/ui/motion3/Motion3SceneDecorator.kt
@@ -1,0 +1,104 @@
+package com.seiko.keystoreviewer.ui.motion3
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.TransformOrigin
+import androidx.compose.ui.layout.layout
+import androidx.compose.ui.platform.LocalDensity
+import androidx.navigation3.runtime.NavEntry
+import androidx.navigation3.scene.Scene
+import androidx.navigation3.scene.SceneDecoratorStrategy
+
+/**
+ * Wraps every scene in a layer that applies the [Motion3] transform
+ * (scale, translation, alpha, rounded clip) and draws the predictive-back scrim
+ * behind the closing surface.
+ */
+@Composable
+fun <T : Any> rememberMotion3SceneDecoratorStrategy(
+  motion: Motion3,
+): SceneDecoratorStrategy<T> = remember(motion) {
+  SceneDecoratorStrategy { scene ->
+    Motion3Scene(scene, motion)
+  }
+}
+
+private data class Motion3Scene<T : Any>(
+  private val scene: Scene<T>,
+  private val motion: Motion3,
+) : Scene<T> {
+  override val key: Any = scene.key
+  override val entries: List<NavEntry<T>> = scene.entries
+  override val previousEntries: List<NavEntry<T>> = scene.previousEntries
+  override val metadata: Map<String, Any> = scene.metadata
+
+  override val content: @Composable () -> Unit = {
+    val role = motion.roleFor(key)
+    Motion3MotionLayer(
+      role = role,
+      motion = motion,
+    ) {
+      scene.content()
+    }
+  }
+}
+
+@Composable
+private fun Motion3MotionLayer(
+  role: SceneRole,
+  motion: Motion3,
+  modifier: Modifier = Modifier,
+  content: @Composable () -> Unit,
+) {
+  val density = LocalDensity.current
+  val enteringOffsetPx = with(density) { motion.spec.enteringStartOffset.toPx() }
+  val marginPx = with(density) { motion.spec.margin.toPx() }
+  val shape = RoundedCornerShape(motion.spec.cornerRadius)
+  val contentModifier = Modifier
+    .fillMaxSize()
+    .layout { measurable, constraints ->
+      val placeable = measurable.measure(constraints)
+      layout(placeable.width, placeable.height) {
+        placeable.placeWithLayer(0, 0) {
+          val transform = motion.transformFor(
+            role = role,
+            widthPx = placeable.width.toFloat(),
+            heightPx = placeable.height.toFloat(),
+            enteringOffsetPx = enteringOffsetPx,
+            marginPx = marginPx,
+          )
+          translationX = transform.translationX
+          translationY = transform.translationY
+          scaleX = transform.scale
+          scaleY = transform.scale
+          alpha = transform.alpha
+          transformOrigin = TransformOrigin(0f, 0f)
+          clip = transform.clip
+          this.shape = shape
+        }
+      }
+    }
+
+  Box(
+    modifier = modifier
+      .fillMaxSize()
+      .drawBehind {
+        if (role == SceneRole.CLOSING) {
+          val alpha = motion.scrimAlpha()
+          if (alpha > 0f) {
+            drawRect(Color.Black.copy(alpha = alpha))
+          }
+        }
+      },
+  ) {
+    Box(modifier = contentModifier) {
+      content()
+    }
+  }
+}

--- a/androidApp/src/main/kotlin/com/seiko/keystoreviewer/ui/motion3/Motion3Spec.kt
+++ b/androidApp/src/main/kotlin/com/seiko/keystoreviewer/ui/motion3/Motion3Spec.kt
@@ -1,0 +1,65 @@
+package com.seiko.keystoreviewer.ui.motion3
+
+import androidx.compose.animation.core.CubicBezierEasing
+import androidx.compose.animation.core.Easing
+import androidx.compose.animation.core.Spring
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * Tunables of the activity-style motion transition.
+ *
+ * @param durationMillis duration of the non-predictive push/pop transitions.
+ * @param maxScale how small the closing surface becomes at full gesture progress.
+ * @param darkScrimAlpha scrim alpha used on dark surfaces.
+ * @param lightScrimAlpha scrim alpha used on light surfaces; also drives the
+ *   predictive-back scrim through the back handler.
+ * @param enteringStartOffset how far the entering surface sits off-screen before
+ *   sliding in.
+ * @param margin gap kept between the closing surface and the screen edge.
+ * @param cornerRadius applied to surfaces while the transition clips them.
+ * @param gestureEasing maps the raw gesture progress reported by the system onto
+ *   the visual progress.
+ * @param followTouchVertically when `true` the closing surface also follows the
+ *   finger vertically; turn it off to keep the surface vertically centred and let
+ *   the gesture drive only the horizontal shift and scale.
+ * @param maxYShiftFraction fraction of the surface height available for the
+ *   vertical shift (before the margin is subtracted).
+ * @param verticalEasing maps the finger's travelled distance onto the vertical
+ *   shift limit with a decelerating curve.
+ * @param settleStiffness stiffness of the spring that finishes the gesture once
+ *   the finger lifts; a spring (rather than a fixed tween) is what lets the
+ *   settle animation inherit the gesture velocity.
+ * @param settleDampingRatio damping ratio of the settle spring.
+ */
+data class Motion3Spec(
+  val durationMillis: Int = DEFAULT_DURATION_MILLIS,
+  val maxScale: Float = DEFAULT_MAX_SCALE,
+  val darkScrimAlpha: Float = DEFAULT_DARK_SCRIM_ALPHA,
+  val lightScrimAlpha: Float = DEFAULT_LIGHT_SCRIM_ALPHA,
+  val enteringStartOffset: Dp = DEFAULT_ENTERING_START_OFFSET,
+  val margin: Dp = DEFAULT_MARGIN,
+  val cornerRadius: Dp = DEFAULT_CORNER_RADIUS,
+  val gestureEasing: Easing = DEFAULT_GESTURE_EASING,
+  val followTouchVertically: Boolean = DEFAULT_FOLLOW_TOUCH_VERTICALLY,
+  val maxYShiftFraction: Float = DEFAULT_MAX_Y_SHIFT_FRACTION,
+  val verticalEasing: Easing = DEFAULT_VERTICAL_EASING,
+  val settleStiffness: Float = DEFAULT_SETTLE_STIFFNESS,
+  val settleDampingRatio: Float = DEFAULT_SETTLE_DAMPING_RATIO,
+) {
+  companion object {
+    const val DEFAULT_DURATION_MILLIS: Int = 300
+    const val DEFAULT_MAX_SCALE: Float = 0.9f
+    const val DEFAULT_DARK_SCRIM_ALPHA: Float = 0.8f
+    const val DEFAULT_LIGHT_SCRIM_ALPHA: Float = 0.2f
+    val DEFAULT_ENTERING_START_OFFSET: Dp = 96.dp
+    val DEFAULT_MARGIN: Dp = 8.dp
+    val DEFAULT_CORNER_RADIUS: Dp = 24.dp
+    val DEFAULT_GESTURE_EASING: Easing = CubicBezierEasing(0.1f, 0.1f, 0f, 1f)
+    const val DEFAULT_FOLLOW_TOUCH_VERTICALLY: Boolean = true
+    const val DEFAULT_MAX_Y_SHIFT_FRACTION: Float = 1f / 20f
+    val DEFAULT_VERTICAL_EASING: Easing = CubicBezierEasing(0f, 0f, 0f, 1f)
+    const val DEFAULT_SETTLE_STIFFNESS: Float = Spring.StiffnessMediumLow
+    const val DEFAULT_SETTLE_DAMPING_RATIO: Float = Spring.DampingRatioNoBouncy
+  }
+}

--- a/androidApp/src/main/kotlin/com/seiko/keystoreviewer/ui/motion3/Motion3Transitions.kt
+++ b/androidApp/src/main/kotlin/com/seiko/keystoreviewer/ui/motion3/Motion3Transitions.kt
@@ -1,0 +1,53 @@
+package com.seiko.keystoreviewer.ui.motion3
+
+import androidx.compose.animation.ContentTransform
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
+import androidx.navigationevent.NavigationEvent
+
+/**
+ * Non-predictive push: the entering surface slides in from the end while the
+ * exiting one slides a third of the way out and fades quickly.
+ */
+fun motion3TransitionSpec(
+  durationMillis: Int = Motion3Spec.DEFAULT_DURATION_MILLIS,
+): ContentTransform = ContentTransform(
+  targetContentEnter = slideInHorizontally(tween(durationMillis)) { it } +
+    fadeIn(tween(durationMillis)),
+  initialContentExit = slideOutHorizontally(tween(durationMillis)) { -it / 3 } +
+    fadeOut(tween(durationMillis / 2)),
+)
+
+/** Non-predictive pop: mirror image of [motion3TransitionSpec]. */
+fun motion3PopTransitionSpec(
+  durationMillis: Int = Motion3Spec.DEFAULT_DURATION_MILLIS,
+): ContentTransform = ContentTransform(
+  targetContentEnter = slideInHorizontally(tween(durationMillis)) { -it / 3 } +
+    fadeIn(tween(durationMillis)),
+  initialContentExit = slideOutHorizontally(tween(durationMillis)) { it } +
+    fadeOut(tween(durationMillis / 2)),
+)
+
+/**
+ * Predictive pop: both surfaces hold their position because the scene decorator
+ * already shows the gesture-driven transform; this only keeps them stable while
+ * the commit animation plays.
+ */
+@Suppress("UNUSED_PARAMETER")
+fun motion3PredictivePopTransitionSpec(
+  @NavigationEvent.SwipeEdge swipeEdge: Int = NavigationEvent.EDGE_NONE,
+  durationMillis: Int = Motion3Spec.DEFAULT_DURATION_MILLIS,
+): ContentTransform = ContentTransform(
+  targetContentEnter = fadeIn(
+    animationSpec = tween(durationMillis, easing = FastOutSlowInEasing),
+    initialAlpha = 1f,
+  ),
+  initialContentExit = fadeOut(
+    animationSpec = tween(durationMillis, easing = FastOutSlowInEasing),
+    targetAlpha = 1f,
+  ),
+)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
   alias(libs.plugins.jetbrainsCompose) apply false
   alias(libs.plugins.compose.compiler) apply false
   alias(libs.plugins.kotlinMultiplatform) apply false
+  alias(libs.plugins.kotlinSerialization) apply false
   alias(libs.plugins.spotless)
 }
 

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
   id("com.android.kotlin.multiplatform.library")
   alias(libs.plugins.jetbrainsCompose)
   alias(libs.plugins.compose.compiler)
+  id("org.jetbrains.kotlin.plugin.serialization")
 }
 
 kotlin {

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -35,6 +35,7 @@ kotlin {
       implementation(libs.androidx.activity.compose)
       implementation(libs.accompanist.permissions)
       implementation(libs.molecule.runtime)
+      implementation(libs.androidx.navigationevent.compose)
     }
     val desktopMain by getting
     desktopMain.dependencies {

--- a/composeApp/src/commonMain/kotlin/data/model/SignSource.kt
+++ b/composeApp/src/commonMain/kotlin/data/model/SignSource.kt
@@ -1,10 +1,15 @@
 package data.model
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 sealed interface SignSource {
+  @Serializable
   data class PackageName(
     val packageName: String,
   ) : SignSource
 
+  @Serializable
   data class Apk(
     val filePath: String,
   ) : SignSource

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,8 @@ androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-co
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version = "1.19.0" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version = "1.13.0" }
 
+androidx-navigationevent-compose = { module = "androidx.navigationevent:navigationevent-compose", version = "1.1.1" }
+
 kotlinx-io = { module = "org.jetbrains.kotlinx:kotlinx-io-core", version = "0.9.1" }
 
 compose-ui-tooling = { module = "org.jetbrains.compose.ui:ui-tooling", version.ref = "compose-plugin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,4 +38,5 @@ kotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 jetbrainsCompose = { id = "org.jetbrains.compose", version.ref = "compose-plugin" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
+kotlinSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }


### PR DESCRIPTION
## 内容

本地实现 Activity 风格的 Motion3 转场系统（含预测性返回手势），应用于 详情页 推入/返回。

### 新增模块 `androidApp/.../ui/motion3/`

| 文件 | 职责 |
|---|---|
| `Motion3Spec` | 动效参数：时长、缩放、scrim、边距/圆角、手势缓动、垂直跟手、settle spring |
| `Motion3` | 手势状态机（GESTURE → CANCEL/COMPLETE）：缓动进度、按帧时间戳采样速度、settle spring 继承手指速度 |
| `Motion3SceneDecoratorStrategy` | 按场景角色（CLOSING/ENTERING）应用 缩放/位移/透明度/圆角裁剪，绘制预测性返回 scrim |
| `Motion3BackHandler` | 把 androidx.navigationevent 预测性返回桥接进动效，目标页通过 `motion3Metadata()` 显式开启 |
| `Motion3Transitions` | push / pop / predictive-pop 三种 ContentTransform |
| `Motion3Metadata` | `NavMetadataKey` + `motion3Metadata()` |

### 集成
- `MainActivity` 改为 scene-state 驱动的 `NavDisplay`（`rememberSceneState` + `rememberNavigationEventState` + `SinglePaneSceneStrategy`）
- `SignatureDetail` 路由挂 `motion3Metadata()`；列表页保持默认转场
- Manifest 开启 `android:enableOnBackInvokedCallback`
- 新依赖：`androidx.navigationevent:navigationevent-compose:1.1.1`（仅 androidApp）

## 验证
- ✅ `androidApp:assembleDebug/Release` + `composeApp:compileKotlinDesktop`
- ✅ `spotlessCheck`
- ✅ 预测性返回：列表⇄详情推入/弹出正常，详情页左滑可跟手缩放返回
- ✅ 脱敏：无外部项目引用，包名 `com.seiko.keystoreviewer.ui.motion3`，注释全部重写

> 基于 `refactor/navigation3`（PR #6），合并顺序：#5 → #6 → 本 PR。