### PR TITLE
ci: tag-driven release to GitHub Release / Google Play

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - uses: gradle/actions/setup-gradle@v4
+
+      - name: Check
+        run: ./gradlew spotlessCheck :androidApp:assembleDebug :desktopApp:compileKotlin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,97 @@
+name: Release
+
+# Tag-driven release (push a `vX.Y.Z` tag):
+#   1. Build the signed release APK and AAB (signing materials come from secrets).
+#   2. Publish the APK to a GitHub Release (external distribution; this is also
+#      what F-Droid's tag-based update check observes — F-Droid builds from
+#      source on their own infrastructure, there is no developer upload API).
+#   3. If PLAY_SERVICE_ACCOUNT_JSON_B64 is configured, upload the AAB to
+#      Google Play via fastlane supply (internal track by default).
+
+on:
+  push:
+    tags: [ 'v*' ]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env:
+      KEYSTORE_B64: ${{ secrets.KEYSTORE_B64 }}
+      KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+      KEYSTORE_KEY_PASSWORD: ${{ secrets.KEYSTORE_KEY_PASSWORD }}
+      KEYSTORE_ALIAS: ${{ secrets.KEYSTORE_ALIAS }}
+      PLAY_SERVICE_ACCOUNT_JSON_B64: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON_B64 }}
+      PLAY_TRACK: ${{ vars.PLAY_TRACK || 'internal' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - uses: gradle/actions/setup-gradle@v4
+
+      - name: Verify tag matches versionName
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          version="$(sed -n 's/.*versionName = "\(.*\)"/\1/p' androidApp/build.gradle.kts)"
+          if [ "v$version" != "$GITHUB_REF_NAME" ]; then
+            echo "::error::Tag $GITHUB_REF_NAME does not match versionName v$version."
+            exit 1
+          fi
+
+      - name: Prepare signing materials
+        env:
+          RUNNER_TEMP: ${{ runner.temp }}
+        run: |
+          if [ -z "$KEYSTORE_B64" ]; then
+            echo "::error::Missing signing secrets. Configure KEYSTORE_B64, KEYSTORE_PASSWORD and KEYSTORE_KEY_PASSWORD (see README, Release section)."
+            exit 1
+          fi
+          dir="$RUNNER_TEMP/signing"
+          mkdir -p "$dir"
+          echo "$KEYSTORE_B64" | base64 --decode > "$dir/keystore-viewer-release.keystore"
+          cat > "$dir/release-signing.properties" <<PROPS
+          storeFile=keystore-viewer-release.keystore
+          storePassword=$KEYSTORE_PASSWORD
+          keyAlias=${KEYSTORE_ALIAS:-KeyStoreViewer}
+          keyPassword=$KEYSTORE_KEY_PASSWORD
+          PROPS
+          echo "signing.dir=$dir" >> local.properties
+
+      - name: Build artifacts
+        run: ./gradlew :androidApp:renameReleaseApk :androidApp:bundleRelease
+
+      - name: Create GitHub Release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: androidApp/build/outputs/apk-named/release/*.apk
+
+      - name: Decode Play service account
+        if: env.PLAY_SERVICE_ACCOUNT_JSON_B64 != ''
+        env:
+          RUNNER_TEMP: ${{ runner.temp }}
+        run: |
+          echo "$PLAY_SERVICE_ACCOUNT_JSON_B64" | base64 --decode > "$RUNNER_TEMP/play-service-account.json"
+
+      - uses: ruby/setup-ruby@v1
+        if: env.PLAY_SERVICE_ACCOUNT_JSON_B64 != ''
+        with:
+          ruby-version: '3.3'
+
+      - name: Upload to Google Play
+        if: env.PLAY_SERVICE_ACCOUNT_JSON_B64 != ''
+        working-directory: fastlane
+        env:
+          PLAY_SERVICE_ACCOUNT_JSON: ${{ runner.temp }}/play-service-account.json
+          AAB_PATH: ${{ github.workspace }}/androidApp/build/outputs/bundle/release/androidApp-release.aab
+        run: |
+          bundle install
+          bundle exec fastlane android play_upload

--- a/README.md
+++ b/README.md
@@ -19,3 +19,32 @@ This is a Kotlin Multiplatform project targeting Android, Desktop.
 * `/desktopApp` is the Compose Desktop application that depends on `/shared`.
 
 Learn more about [Kotlin Multiplatform](https://www.jetbrains.com/help/kotlin-multiplatform-dev/get-started.html)…
+
+Releasing
+---------
+
+Release flow: bump `versionCode`/`versionName` in `androidApp/build.gradle.kts` (and
+`packageVersion` in `desktopApp/build.gradle.kts`), then push a matching `vX.Y.Z` tag.
+The `Release` workflow builds the signed APK/AAB and attaches the APK to a GitHub Release.
+
+Required repository secrets:
+
+| Secret | Description |
+| --- | --- |
+| `KEYSTORE_B64` | Base64 of `keystore-viewer-release.keystore` (macOS: `base64 -i file`, Linux: `base64 -w0 file`) |
+| `KEYSTORE_PASSWORD` | Keystore `storePassword` |
+| `KEYSTORE_KEY_PASSWORD` | Keystore `keyPassword` |
+| `KEYSTORE_ALIAS` | Optional, defaults to `KeyStoreViewer` |
+| `PLAY_SERVICE_ACCOUNT_JSON_B64` | Optional, base64 of a Google Play service-account JSON; enables automatic upload of the AAB to the internal track |
+
+Optional repository variable: `PLAY_TRACK` (defaults to `internal`).
+
+- **Google Play**: fully automated when `PLAY_SERVICE_ACCOUNT_JSON_B64` is set — the AAB is
+  uploaded via fastlane `supply` (`fastlane/play_upload` lane).
+- **F-Droid**: there is no developer upload API — F-Droid builds from source on their own
+  infrastructure. Tagged releases are picked up by F-Droid's update check (tag based);
+  build recipe changes require a merge request against their `fdroiddata` metadata.
+
+Signing materials live outside this repository. CI resolves them via secrets; locally,
+point `signing.dir` in `local.properties` to the directory containing
+`release-signing.properties` and the keystore.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,0 +1,16 @@
+default_platform(:android)
+
+platform :android do
+  desc 'Upload the release AAB to Google Play (internal track by default)'
+  lane :play_upload do
+    supply(
+      json_key: ENV.fetch('PLAY_SERVICE_ACCOUNT_JSON'),
+      aab: ENV.fetch('AAB_PATH'),
+      track: ENV.fetch('PLAY_TRACK', 'internal'),
+      skip_upload_metadata: true,
+      skip_upload_changelogs: true,
+      skip_upload_images: true,
+      skip_upload_screenshots: true
+    )
+  end
+end

--- a/fastlane/Gemfile
+++ b/fastlane/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'fastlane', '~> 2.226'


### PR DESCRIPTION
## Summary
- `Release` workflow: pushing a `vX.Y.Z` tag builds the signed release APK + AAB, attaches the APK to a GitHub Release, and (when the Play secret is configured) uploads the AAB to Google Play via fastlane `supply` (internal track by default)
- `CI` workflow: spotless + assembleDebug + desktop compile on PRs/pushes to main
- `fastlane` Fastfile/Gemfile with a `play_upload` lane (metadata/screenshots upload skipped)
- README: release process + required secrets documented
- F-Droid note: no developer upload API exists — F-Droid builds from source and observes tagged releases; build recipe changes go through fdroiddata MRs

## Required secrets (see README)
- `KEYSTORE_B64` / `KEYSTORE_PASSWORD` / `KEYSTORE_KEY_PASSWORD` / optional `KEYSTORE_ALIAS`
- Optional `PLAY_SERVICE_ACCOUNT_JSON_B64` + repo variable `PLAY_TRACK`

## Verification
- Gradle tasks used by CI verified locally: `:androidApp:renameReleaseApk` / `:androidApp:bundleRelease` ✅
- Workflow YAML + Fastfile syntax validated ✅