### PR TITLE
chore: gitignore local planning docs (.planning/)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ pepk.jar
 
 # pi session artifacts
 .pi/
+
+# local planning docs
+.planning/


### PR DESCRIPTION
Keep local planning documents out of the repository.