### PR TITLE
feat: isolate ads via foss/play flavors

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,14 +65,14 @@ jobs:
           echo "signing.dir=$dir" >> local.properties
 
       - name: Build artifacts
-        run: ./gradlew :androidApp:renameReleaseApk :androidApp:bundleRelease
+        run: ./gradlew :androidApp:renameFossReleaseApk :androidApp:bundlePlayRelease
 
       - name: Create GitHub Release
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
-          files: androidApp/build/outputs/apk-named/release/*.apk
+          files: androidApp/build/outputs/apk-named/foss/release/*.apk
 
       - name: Decode Play service account
         if: env.PLAY_SERVICE_ACCOUNT_JSON_B64 != ''
@@ -91,7 +91,7 @@ jobs:
         working-directory: fastlane
         env:
           PLAY_SERVICE_ACCOUNT_JSON: ${{ runner.temp }}/play-service-account.json
-          AAB_PATH: ${{ github.workspace }}/androidApp/build/outputs/bundle/release/androidApp-release.aab
+          AAB_PATH: ${{ github.workspace }}/androidApp/build/outputs/bundle/playRelease/androidApp-play-release.aab
         run: |
           bundle install
           bundle exec fastlane android play_upload

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -23,6 +23,16 @@ android {
     }
   }
 
+  flavorDimensions += "store"
+  productFlavors {
+    create("foss") {
+      dimension = "store"
+    }
+    create("play") {
+      dimension = "store"
+    }
+  }
+
   packaging {
     resources {
       excludes += "/META-INF/{AL2.0,LGPL2.1}"
@@ -105,6 +115,7 @@ kotlin {
 
 dependencies {
   implementation(projects.shared)
+  "playImplementation"(libs.play.services.ads)
   implementation(libs.androidx.activity.compose)
   implementation(libs.navigation3.runtime)
   implementation(libs.navigation3.ui)
@@ -121,13 +132,15 @@ val gitCommit: String =
     ""
   }
 
-fun renameApkTask(variant: String) = tasks.register<Copy>("rename${variant.replaceFirstChar { it.uppercase() }}Apk") {
-  dependsOn("assemble${variant.replaceFirstChar { it.uppercase() }}")
-  from(layout.buildDirectory.dir("outputs/apk/${variant.lowercase()}"))
-  include("*.apk")
-  into(layout.buildDirectory.dir("outputs/apk-named/${variant.lowercase()}"))
-  rename { "keystoreviewer-${variant.lowercase()}-${android.defaultConfig.versionName}-$gitCommit.apk" }
+listOf("foss", "play").forEach { flavor ->
+  listOf("Debug", "Release").forEach { variant ->
+    val variantName = flavor.replaceFirstChar { it.uppercase() } + variant
+    tasks.register<Copy>("rename${variantName}Apk") {
+      dependsOn("assemble$variantName")
+      from(layout.buildDirectory.dir("outputs/apk/${flavor.lowercase()}/${variant.lowercase()}"))
+      include("*.apk")
+      into(layout.buildDirectory.dir("outputs/apk-named/${flavor.lowercase()}/${variant.lowercase()}"))
+      rename { "keystoreviewer-${flavor.lowercase()}-${variant.lowercase()}-${android.defaultConfig.versionName}-$gitCommit.apk" }
+    }
+  }
 }
-
-renameApkTask("debug")
-renameApkTask("release")

--- a/androidApp/src/foss/kotlin/com/seiko/keystoreviewer/ads/Ads.kt
+++ b/androidApp/src/foss/kotlin/com/seiko/keystoreviewer/ads/Ads.kt
@@ -1,0 +1,14 @@
+package com.seiko.keystoreviewer.ads
+
+import android.content.Context
+import platform.ads.AdSlot
+import platform.ads.NoAdSlot
+
+/**
+ * foss 变体(F-Droid / GitHub Release):无任何广告能力与广告依赖。
+ */
+object Ads {
+  fun initialize(context: Context) = Unit
+
+  fun slot(): AdSlot = NoAdSlot
+}

--- a/androidApp/src/main/kotlin/com/seiko/keystoreviewer/MainActivity.kt
+++ b/androidApp/src/main/kotlin/com/seiko/keystoreviewer/MainActivity.kt
@@ -15,6 +15,7 @@ import androidx.navigation3.scene.SinglePaneSceneStrategy
 import androidx.navigation3.scene.rememberNavigationEventState
 import androidx.navigation3.scene.rememberSceneState
 import androidx.navigation3.ui.NavDisplay
+import com.seiko.keystoreviewer.ads.Ads
 import com.seiko.keystoreviewer.ui.motion3.Motion3BackHandler
 import com.seiko.keystoreviewer.ui.motion3.motion3Metadata
 import com.seiko.keystoreviewer.ui.motion3.motion3PopTransitionSpec
@@ -26,6 +27,7 @@ import data.model.SignSource
 import kotlinx.serialization.Serializable
 import platform.ContentHandler
 import platform.LocalContentHandler
+import platform.ads.LocalAdSlot
 import ui.screen.AppListScreen
 import ui.screen.SignatureDetailScreen
 import ui.theme.AppTheme
@@ -35,10 +37,12 @@ class MainActivity : ComponentActivity() {
     enableEdgeToEdge()
     super.onCreate(savedInstanceState)
     val contentHandler = ContentHandler(applicationContext)
+    Ads.initialize(applicationContext)
     setContent {
       AppTheme {
         CompositionLocalProvider(
           LocalContentHandler provides contentHandler,
+          LocalAdSlot provides Ads.slot(),
         ) {
           KeyStoreViewerApp()
         }

--- a/androidApp/src/play/AndroidManifest.xml
+++ b/androidApp/src/play/AndroidManifest.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+  <application>
+    <!-- AdMob 测试 App ID;正式 ID 在 M3 接入,仅存在于 play 变体 -->
+    <meta-data
+      android:name="com.google.android.gms.ads.APPLICATION_ID"
+      android:value="ca-app-pub-3940256099942544~3347511713" />
+  </application>
+
+</manifest>

--- a/androidApp/src/play/kotlin/com/seiko/keystoreviewer/ads/AdmobAdSlot.kt
+++ b/androidApp/src/play/kotlin/com/seiko/keystoreviewer/ads/AdmobAdSlot.kt
@@ -1,0 +1,38 @@
+package com.seiko.keystoreviewer.ads
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.viewinterop.AndroidView
+import com.google.android.gms.ads.AdRequest
+import com.google.android.gms.ads.AdSize
+import com.google.android.gms.ads.AdView
+import platform.ads.AdSlot
+
+/**
+ * M1 阶段使用 Google 官方测试 ID;正式 ad unit ID 在 M3 接入,
+ * 届时经 play 变体 BuildConfig 注入,不落仓库。
+ */
+object AdmobAdSlot : AdSlot {
+
+  private const val TEST_BANNER_AD_UNIT = "ca-app-pub-3940256099942544/6300978111"
+
+  @Composable
+  override fun Banner(modifier: Modifier) {
+    AndroidView(
+      modifier = modifier.fillMaxWidth(),
+      factory = { context ->
+        AdView(context).apply {
+          setAdSize(AdSize.BANNER)
+          adUnitId = TEST_BANNER_AD_UNIT
+        }
+      },
+      update = { adView -> adView.loadAd(AdRequest.Builder().build()) },
+    )
+  }
+
+  @Composable
+  override fun InlineNative(modifier: Modifier) = Unit
+
+  override fun maybeShowInterstitial(placement: String) = Unit
+}

--- a/androidApp/src/play/kotlin/com/seiko/keystoreviewer/ads/Ads.kt
+++ b/androidApp/src/play/kotlin/com/seiko/keystoreviewer/ads/Ads.kt
@@ -1,0 +1,13 @@
+package com.seiko.keystoreviewer.ads
+
+import android.content.Context
+import com.google.android.gms.ads.MobileAds
+import platform.ads.AdSlot
+
+object Ads {
+  fun initialize(context: Context) {
+    MobileAds.initialize(context) {}
+  }
+
+  fun slot(): AdSlot = AdmobAdSlot
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,6 +31,8 @@ accompanist-permissions = { module = "com.google.accompanist:accompanist-permiss
 okio = { module = "com.squareup.okio:okio", version = "3.18.2" }
 material-kolor = { module = "com.materialkolor:material-kolor", version = "5.0.1" }
 
+play-services-ads = { module = "com.google.android.gms:play-services-ads", version = "25.4.0" }
+
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }
 androidLibrary = { id = "com.android.library", version.ref = "agp" }

--- a/shared/src/commonMain/kotlin/platform/ads/AdSlot.kt
+++ b/shared/src/commonMain/kotlin/platform/ads/AdSlot.kt
@@ -1,0 +1,30 @@
+package platform.ads
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.Modifier
+
+/**
+ * 广告展示能力的抽象。
+ *
+ * 实现按 flavor 隔离在 androidApp 中:play 变体提供 AdMob 实现,
+ * foss 变体(F-Droid / GitHub Release)永远只有 [NoAdSlot],
+ * 广告 SDK 依赖与代码对 foss 构建物理不可见。
+ */
+interface AdSlot {
+  @Composable fun Banner(modifier: Modifier = Modifier)
+
+  @Composable fun InlineNative(modifier: Modifier = Modifier)
+
+  fun maybeShowInterstitial(placement: String)
+}
+
+data object NoAdSlot : AdSlot {
+  @Composable override fun Banner(modifier: Modifier) = Unit
+
+  @Composable override fun InlineNative(modifier: Modifier) = Unit
+
+  override fun maybeShowInterstitial(placement: String) = Unit
+}
+
+val LocalAdSlot = staticCompositionLocalOf<AdSlot> { NoAdSlot }


### PR DESCRIPTION
## Summary (Phase M1 of monetization plan)
- `AdSlot` interface + `LocalAdSlot` in shared (default NoOp, zero ad deps); MainActivity provides it via CompositionLocal
- `foss` / `play` product flavors in androidApp; `playImplementation` only for the play variant (string config accessor)
- play flavor: AdMob shell with Google **test** IDs (banner AdView + manifest APPLICATION_ID)
- foss flavor: pure no-op — **verified**: foss dex contains 0 `gms.ads` traces, foss manifest has no AdMob meta-data
- release workflow: GitHub Release now ships `fossRelease` APK, Play upload consumes `playRelease` AAB
- rename tasks reworked for flavors (`renameFossReleaseApk` etc.)

## Verification
- `assembleFossRelease` / `assemblePlayRelease` / `renameFossReleaseApk` / `bundlePlayRelease` / desktop compile ✅
- foss dex: 0 × `com.google.android.gms.ads`; play dex: 12 ✅
- foss release APK signed with release key (ccffaadd…) ✅