### PR TITLE
chore: inject AdMob App ID via manifestPlaceholder (not committed)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,7 @@ jobs:
       KEYSTORE_ALIAS: ${{ secrets.KEYSTORE_ALIAS }}
       PLAY_SERVICE_ACCOUNT_JSON_B64: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON_B64 }}
       PLAY_TRACK: ${{ vars.PLAY_TRACK || 'internal' }}
+      ADMOB_APP_ID: ${{ secrets.ADMOB_APP_ID }}
     steps:
       - uses: actions/checkout@v4
 

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -12,6 +12,15 @@ android {
   namespace = "com.seiko.keystoreviewer"
   compileSdk = libs.versions.android.compileSdk.get().toInt()
 
+  val localProperties = Properties().apply {
+    rootProject.file("local.properties").takeIf { it.exists() }?.inputStream()?.use { load(it) }
+  }
+  // AdMob App ID:本地经 local.properties(admob.appId),CI 经 ADMOB_APP_ID secret,
+  // 缺失时回退 Google 官方测试 ID,永不入 git
+  val admobAppId = localProperties.getProperty("admob.appId")
+    ?: System.getenv("ADMOB_APP_ID")
+    ?: "ca-app-pub-3940256099942544~3347511713"
+
   defaultConfig {
     applicationId = "com.seiko.keystoreviewer"
     minSdk = libs.versions.android.minSdk.get().toInt()
@@ -30,6 +39,7 @@ android {
     }
     create("play") {
       dimension = "store"
+      manifestPlaceholders["admobAppId"] = admobAppId
     }
   }
 
@@ -41,9 +51,6 @@ android {
 
   // Signing materials live outside this repository; point to them via
   // `signing.dir` in local.properties or the KEYSTORE_VIEWER_SIGNING_DIR env var.
-  val localProperties = Properties().apply {
-    rootProject.file("local.properties").takeIf { it.exists() }?.inputStream()?.use { load(it) }
-  }
   val signingDir = localProperties.getProperty("signing.dir")
     ?: System.getenv("KEYSTORE_VIEWER_SIGNING_DIR")
     ?: file("signing").path

--- a/androidApp/src/play/AndroidManifest.xml
+++ b/androidApp/src/play/AndroidManifest.xml
@@ -2,10 +2,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
   <application>
-    <!-- AdMob 测试 App ID;正式 ID 在 M3 接入,仅存在于 play 变体 -->
+    <!-- AdMob App ID 由 manifestPlaceholder 注入(本地: local.properties admob.appId;CI: ADMOB_APP_ID secret),不落仓库 -->
     <meta-data
       android:name="com.google.android.gms.ads.APPLICATION_ID"
-      android:value="ca-app-pub-3940256099942544~3347511713" />
+      android:value="${admobAppId}" />
   </application>
 
 </manifest>


### PR DESCRIPTION
AdMob App ID stays out of git: resolved from `admob.appId` in local.properties (local builds) or the `ADMOB_APP_ID` secret (CI), falling back to the Google test App ID. Verified the real ID lands in the play variant merged manifest.