### PR TITLE
feat: rewarded ad capability in AdSlot (play flavor)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ jobs:
       PLAY_SERVICE_ACCOUNT_JSON_B64: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON_B64 }}
       PLAY_TRACK: ${{ vars.PLAY_TRACK || 'internal' }}
       ADMOB_APP_ID: ${{ secrets.ADMOB_APP_ID }}
+      ADMOB_REWARDED_ID: ${{ secrets.ADMOB_REWARDED_ID }}
     steps:
       - uses: actions/checkout@v4
 

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -20,6 +20,9 @@ android {
   val admobAppId = localProperties.getProperty("admob.appId")
     ?: System.getenv("ADMOB_APP_ID")
     ?: "ca-app-pub-3940256099942544~3347511713"
+  val admobRewardedId = localProperties.getProperty("admob.rewardedId")
+    ?: System.getenv("ADMOB_REWARDED_ID")
+    ?: "ca-app-pub-3940256099942544/5224354917"
 
   defaultConfig {
     applicationId = "com.seiko.keystoreviewer"
@@ -40,6 +43,7 @@ android {
     create("play") {
       dimension = "store"
       manifestPlaceholders["admobAppId"] = admobAppId
+      buildConfigField("String", "ADMOB_REWARDED_ID", "\"$admobRewardedId\"")
     }
   }
 
@@ -113,6 +117,7 @@ android {
   }
   buildFeatures {
     compose = true
+    buildConfig = true
   }
 }
 

--- a/androidApp/src/foss/kotlin/com/seiko/keystoreviewer/ads/Ads.kt
+++ b/androidApp/src/foss/kotlin/com/seiko/keystoreviewer/ads/Ads.kt
@@ -1,6 +1,6 @@
 package com.seiko.keystoreviewer.ads
 
-import android.content.Context
+import android.app.Activity
 import platform.ads.AdSlot
 import platform.ads.NoAdSlot
 
@@ -8,7 +8,7 @@ import platform.ads.NoAdSlot
  * foss 变体(F-Droid / GitHub Release):无任何广告能力与广告依赖。
  */
 object Ads {
-  fun initialize(context: Context) = Unit
+  fun initialize(activity: Activity) = Unit
 
   fun slot(): AdSlot = NoAdSlot
 }

--- a/androidApp/src/main/kotlin/com/seiko/keystoreviewer/MainActivity.kt
+++ b/androidApp/src/main/kotlin/com/seiko/keystoreviewer/MainActivity.kt
@@ -37,7 +37,7 @@ class MainActivity : ComponentActivity() {
     enableEdgeToEdge()
     super.onCreate(savedInstanceState)
     val contentHandler = ContentHandler(applicationContext)
-    Ads.initialize(applicationContext)
+    Ads.initialize(this)
     setContent {
       AppTheme {
         CompositionLocalProvider(

--- a/androidApp/src/play/kotlin/com/seiko/keystoreviewer/ads/AdmobAdSlot.kt
+++ b/androidApp/src/play/kotlin/com/seiko/keystoreviewer/ads/AdmobAdSlot.kt
@@ -1,21 +1,42 @@
 package com.seiko.keystoreviewer.ads
 
+import android.app.Activity
+import android.content.Context
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.viewinterop.AndroidView
+import com.google.android.gms.ads.AdError
 import com.google.android.gms.ads.AdRequest
 import com.google.android.gms.ads.AdSize
 import com.google.android.gms.ads.AdView
+import com.google.android.gms.ads.FullScreenContentCallback
+import com.google.android.gms.ads.MobileAds
+import com.google.android.gms.ads.rewarded.RewardedAd
+import com.google.android.gms.ads.rewarded.RewardedAdLoadCallback
+import com.seiko.keystoreviewer.BuildConfig
 import platform.ads.AdSlot
+import java.lang.ref.WeakReference
 
 /**
- * M1 阶段使用 Google 官方测试 ID;正式 ad unit ID 在 M3 接入,
- * 届时经 play 变体 BuildConfig 注入,不落仓库。
+ * M1 阶段 Banner 使用 Google 官方测试 ID;正式 banner/native/interstitial ID 在 M3 接入。
+ * Rewarded ID 经 play 变体 BuildConfig 注入(不入 git)。
  */
 object AdmobAdSlot : AdSlot {
 
   private const val TEST_BANNER_AD_UNIT = "ca-app-pub-3940256099942544/6300978111"
+
+  private var appContext: Context? = null
+  private var activityRef: WeakReference<Activity>? = null
+  private var rewardedAd: RewardedAd? = null
+  private var rewardEarned = false
+
+  fun onActivityCreated(activity: Activity) {
+    activityRef = WeakReference(activity)
+    appContext = activity.applicationContext
+    MobileAds.initialize(activity) {}
+    preloadRewarded()
+  }
 
   @Composable
   override fun Banner(modifier: Modifier) {
@@ -35,4 +56,43 @@ object AdmobAdSlot : AdSlot {
   override fun InlineNative(modifier: Modifier) = Unit
 
   override fun maybeShowInterstitial(placement: String) = Unit
+
+  override fun showRewarded(placement: String, onResult: (rewarded: Boolean) -> Unit) {
+    val activity = activityRef?.get()
+    val ad = rewardedAd
+    if (activity == null || ad == null) {
+      onResult(false)
+      preloadRewarded()
+      return
+    }
+    rewardEarned = false
+    ad.fullScreenContentCallback = object : FullScreenContentCallback() {
+      override fun onAdDismissedFullScreenContent() {
+        rewardedAd = null
+        onResult(rewardEarned)
+        preloadRewarded()
+      }
+
+      override fun onAdFailedToShowFullScreenContent(error: AdError) {
+        rewardedAd = null
+        onResult(false)
+        preloadRewarded()
+      }
+    }
+    ad.show(activity) { rewardEarned = true }
+  }
+
+  private fun preloadRewarded() {
+    val context = appContext ?: return
+    RewardedAd.load(
+      context,
+      BuildConfig.ADMOB_REWARDED_ID,
+      AdRequest.Builder().build(),
+      object : RewardedAdLoadCallback() {
+        override fun onAdLoaded(ad: RewardedAd) {
+          rewardedAd = ad
+        }
+      },
+    )
+  }
 }

--- a/androidApp/src/play/kotlin/com/seiko/keystoreviewer/ads/Ads.kt
+++ b/androidApp/src/play/kotlin/com/seiko/keystoreviewer/ads/Ads.kt
@@ -1,12 +1,13 @@
 package com.seiko.keystoreviewer.ads
 
-import android.content.Context
+import android.app.Activity
 import com.google.android.gms.ads.MobileAds
 import platform.ads.AdSlot
 
 object Ads {
-  fun initialize(context: Context) {
-    MobileAds.initialize(context) {}
+  fun initialize(activity: Activity) {
+    AdmobAdSlot.onActivityCreated(activity)
+    MobileAds.initialize(activity) {}
   }
 
   fun slot(): AdSlot = AdmobAdSlot

--- a/shared/src/commonMain/kotlin/platform/ads/AdSlot.kt
+++ b/shared/src/commonMain/kotlin/platform/ads/AdSlot.kt
@@ -17,6 +17,12 @@ interface AdSlot {
   @Composable fun InlineNative(modifier: Modifier = Modifier)
 
   fun maybeShowInterstitial(placement: String)
+
+  /**
+   * 展示激励广告(用户主动触发换解锁功能)。
+   * [onResult] 的参数表示用户是否完整看完并获得奖励。
+   */
+  fun showRewarded(placement: String, onResult: (rewarded: Boolean) -> Unit)
 }
 
 data object NoAdSlot : AdSlot {
@@ -25,6 +31,8 @@ data object NoAdSlot : AdSlot {
   @Composable override fun InlineNative(modifier: Modifier) = Unit
 
   override fun maybeShowInterstitial(placement: String) = Unit
+
+  override fun showRewarded(placement: String, onResult: (rewarded: Boolean) -> Unit) = onResult(false)
 }
 
 val LocalAdSlot = staticCompositionLocalOf<AdSlot> { NoAdSlot }


### PR DESCRIPTION
Adds `showRewarded` to the AdSlot abstraction with a working AdMob implementation (preload + activity-weakref show) in the play flavor. Real rewarded unit ID flows via `ADMOB_REWARDED_ID` secret / `admob.rewardedId` local property into play BuildConfig — never committed. F-Droid foss build remains physically ad-free (verified: 0 gms.ads traces).