### PR TITLE
feat: history, favorites and batch signature report export (M2)

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -127,6 +127,7 @@ kotlin {
 
 dependencies {
   implementation(projects.shared)
+  implementation(libs.kotlinx.serialization.json)
   "playImplementation"(libs.play.services.ads)
   implementation(libs.androidx.activity.compose)
   implementation(libs.navigation3.runtime)

--- a/androidApp/src/foss/kotlin/com/seiko/keystoreviewer/ads/ExportQuotaProvider.kt
+++ b/androidApp/src/foss/kotlin/com/seiko/keystoreviewer/ads/ExportQuotaProvider.kt
@@ -1,0 +1,9 @@
+package com.seiko.keystoreviewer.ads
+
+import android.content.Context
+import data.local.ExportQuota
+import data.local.UnlimitedExportQuota
+
+object ExportQuotaProvider {
+  fun quota(context: Context): ExportQuota = UnlimitedExportQuota
+}

--- a/androidApp/src/main/kotlin/com/seiko/keystoreviewer/MainActivity.kt
+++ b/androidApp/src/main/kotlin/com/seiko/keystoreviewer/MainActivity.kt
@@ -16,6 +16,7 @@ import androidx.navigation3.scene.rememberNavigationEventState
 import androidx.navigation3.scene.rememberSceneState
 import androidx.navigation3.ui.NavDisplay
 import com.seiko.keystoreviewer.ads.Ads
+import com.seiko.keystoreviewer.ads.ExportQuotaProvider
 import com.seiko.keystoreviewer.ui.motion3.Motion3BackHandler
 import com.seiko.keystoreviewer.ui.motion3.motion3Metadata
 import com.seiko.keystoreviewer.ui.motion3.motion3PopTransitionSpec
@@ -23,12 +24,19 @@ import com.seiko.keystoreviewer.ui.motion3.motion3PredictivePopTransitionSpec
 import com.seiko.keystoreviewer.ui.motion3.motion3TransitionSpec
 import com.seiko.keystoreviewer.ui.motion3.rememberMotion3
 import com.seiko.keystoreviewer.ui.motion3.rememberMotion3SceneDecoratorStrategy
+import data.local.FileFavoritesRepository
+import data.local.FileHistoryRepository
+import data.local.LocalExportQuota
+import data.local.LocalFavoritesRepository
+import data.local.LocalHistoryRepository
 import data.model.SignSource
 import kotlinx.serialization.Serializable
 import platform.ContentHandler
 import platform.LocalContentHandler
 import platform.ads.LocalAdSlot
 import ui.screen.AppListScreen
+import ui.screen.FavoritesScreen
+import ui.screen.HistoryScreen
 import ui.screen.SignatureDetailScreen
 import ui.theme.AppTheme
 
@@ -43,6 +51,9 @@ class MainActivity : ComponentActivity() {
         CompositionLocalProvider(
           LocalContentHandler provides contentHandler,
           LocalAdSlot provides Ads.slot(),
+          LocalHistoryRepository provides FileHistoryRepository(applicationContext),
+          LocalFavoritesRepository provides FileFavoritesRepository(applicationContext),
+          LocalExportQuota provides ExportQuotaProvider.quota(applicationContext),
         ) {
           KeyStoreViewerApp()
         }
@@ -53,6 +64,12 @@ class MainActivity : ComponentActivity() {
 
 @Serializable
 data object AppList : NavKey
+
+@Serializable
+data object History : NavKey
+
+@Serializable
+data object Favorites : NavKey
 
 @Serializable
 data class SignatureDetail(val signSource: SignSource) : NavKey
@@ -76,6 +93,32 @@ private fun KeyStoreViewerApp() {
         AppListScreen(
           onItemClick = { signSource ->
             backStack.add(SignatureDetail(signSource))
+          },
+          onOpenHistory = {
+            backStack.add(History)
+          },
+          onOpenFavorites = {
+            backStack.add(Favorites)
+          },
+        )
+      }
+      entry<History>(
+        metadata = motion3Metadata(),
+      ) {
+        HistoryScreen(
+          onBack = onBack,
+          onOpen = { packageName ->
+            backStack.add(SignatureDetail(SignSource.PackageName(packageName)))
+          },
+        )
+      }
+      entry<Favorites>(
+        metadata = motion3Metadata(),
+      ) {
+        FavoritesScreen(
+          onBack = onBack,
+          onOpen = { packageName ->
+            backStack.add(SignatureDetail(SignSource.PackageName(packageName)))
           },
         )
       }

--- a/androidApp/src/main/kotlin/data/local/FileRepositories.kt
+++ b/androidApp/src/main/kotlin/data/local/FileRepositories.kt
@@ -1,0 +1,125 @@
+package data.local
+
+import android.content.Context
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import java.io.File
+
+private val json = Json { ignoreUnknownKeys = true }
+
+/**
+ * 简单文件存储实现(M2 数据量级足够;后续如需查询能力可迁移 Room)。
+ * 写入均为先内存后落盘,调用方在 IO 线程调用。
+ */
+class FileHistoryRepository(
+  context: Context,
+) : HistoryRepository {
+
+  private val file = File(context.filesDir, "history.json")
+  private val maxEntries = 500
+
+  private val state = MutableStateFlow(
+    runCatching {
+      if (file.exists()) {
+        json.decodeFromString(ListSerializer(HistoryEntry.serializer()), file.readText())
+      } else {
+        emptyList()
+      }
+    }.getOrDefault(emptyList()),
+  )
+
+  override val entries = state.asStateFlow()
+
+  private fun persist(entries: List<HistoryEntry>) {
+    runCatching {
+      file.writeText(json.encodeToString(entries))
+    }
+  }
+
+  override suspend fun record(packageName: String, displayName: String) {
+    state.update { current ->
+      val others = current.filterNot { it.packageName == packageName }
+      val entry = HistoryEntry(
+        packageName = packageName,
+        displayName = displayName,
+        viewedAtMillis = System.currentTimeMillis(),
+      )
+      persist(listOf(entry) + others)
+      (listOf(entry) + others).take(maxEntries)
+    }
+  }
+
+  override suspend fun remove(packageName: String) {
+    state.update { current ->
+      val next = current.filterNot { it.packageName == packageName }
+      persist(next)
+      next
+    }
+  }
+
+  override suspend fun clear() {
+    state.update {
+      persist(emptyList())
+      emptyList()
+    }
+  }
+}
+
+class FileFavoritesRepository(
+  context: Context,
+) : FavoritesRepository {
+
+  private val file = File(context.filesDir, "favorites.json")
+
+  private val state = MutableStateFlow(
+    runCatching {
+      if (file.exists()) {
+        json.decodeFromString(ListSerializer(FavoriteEntry.serializer()), file.readText())
+      } else {
+        emptyList()
+      }
+    }.getOrDefault(emptyList()),
+  )
+
+  override val entries = state.asStateFlow()
+
+  private fun persist(entries: List<FavoriteEntry>) {
+    runCatching {
+      file.writeText(json.encodeToString(entries))
+    }
+  }
+
+  override suspend fun toggle(packageName: String, displayName: String) {
+    state.update { current ->
+      if (current.any { it.packageName == packageName }) {
+        val next = current.filterNot { it.packageName == packageName }
+        persist(next)
+        next
+      } else {
+        val entry = FavoriteEntry(
+          packageName = packageName,
+          displayName = displayName,
+          addedAtMillis = System.currentTimeMillis(),
+        )
+        val next = listOf(entry) + current
+        persist(next)
+        next
+      }
+    }
+  }
+
+  override suspend fun contains(packageName: String): Boolean = state.value.any { it.packageName == packageName }
+
+  override suspend fun remove(packageName: String) {
+    state.update { current ->
+      val next = current.filterNot { it.packageName == packageName }
+      persist(next)
+      next
+    }
+  }
+}

--- a/androidApp/src/play/kotlin/com/seiko/keystoreviewer/ads/AdExportQuota.kt
+++ b/androidApp/src/play/kotlin/com/seiko/keystoreviewer/ads/AdExportQuota.kt
@@ -1,0 +1,78 @@
+package com.seiko.keystoreviewer.ads
+
+import android.content.Context
+import data.local.ExportQuota
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import platform.ads.AdSlot
+import java.util.Calendar
+
+/**
+ * play 变体的导出配额:每天 [FREE_PER_DAY] 次免费,看激励广告 +[BONUS_PER_AD] 次。
+ * 配额按本地时区自然日重置。
+ */
+class AdExportQuota(context: Context) : ExportQuota {
+
+  private val prefs = context.getSharedPreferences("export_quota", Context.MODE_PRIVATE)
+
+  private val state = MutableStateFlow(currentRemaining())
+
+  override val remaining = state.asStateFlow()
+
+  private val mutex = Mutex()
+
+  override suspend fun tryConsume(): Boolean = mutex.withLock {
+    if (currentRemaining() <= 0) return false
+    val used = prefs.getInt(KEY_USED, 0)
+    val bonus = prefs.getInt(KEY_BONUS, 0)
+    prefs.edit()
+      .putInt(KEY_DAY, todayKey())
+      .apply {
+        if (used < FREE_PER_DAY) {
+          putInt(KEY_USED, used + 1)
+        } else {
+          putInt(KEY_BONUS, bonus - 1)
+        }
+      }
+      .apply()
+    refresh()
+    true
+  }
+
+  override suspend fun addBonus(count: Int) {
+    mutex.withLock {
+      prefs.edit()
+        .putInt(KEY_DAY, todayKey())
+        .putInt(KEY_BONUS, prefs.getInt(KEY_BONUS, 0) + count)
+        .apply()
+    }
+    refresh()
+  }
+
+  private fun currentRemaining(): Int {
+    if (prefs.getInt(KEY_DAY, todayKey()) != todayKey()) return FREE_PER_DAY
+    val used = prefs.getInt(KEY_USED, 0)
+    val bonus = prefs.getInt(KEY_BONUS, 0)
+    return (FREE_PER_DAY - used).coerceAtLeast(0) + bonus
+  }
+
+  private fun refresh() {
+    state.update { currentRemaining() }
+  }
+
+  private fun todayKey(): Int = Calendar.getInstance().let {
+    it.get(Calendar.YEAR) * 1000 + it.get(Calendar.DAY_OF_YEAR)
+  }
+
+  companion object {
+    const val FREE_PER_DAY = 2
+    private const val BONUS_PER_AD = AdSlot.REWARD_BONUS_COUNT
+
+    private const val KEY_DAY = "day"
+    private const val KEY_USED = "used"
+    private const val KEY_BONUS = "bonus"
+  }
+}

--- a/androidApp/src/play/kotlin/com/seiko/keystoreviewer/ads/AdmobAdSlot.kt
+++ b/androidApp/src/play/kotlin/com/seiko/keystoreviewer/ads/AdmobAdSlot.kt
@@ -82,6 +82,8 @@ object AdmobAdSlot : AdSlot {
     ad.show(activity) { rewardEarned = true }
   }
 
+  override fun canShowRewarded(): Boolean = true
+
   private fun preloadRewarded() {
     val context = appContext ?: return
     RewardedAd.load(

--- a/androidApp/src/play/kotlin/com/seiko/keystoreviewer/ads/ExportQuotaProvider.kt
+++ b/androidApp/src/play/kotlin/com/seiko/keystoreviewer/ads/ExportQuotaProvider.kt
@@ -1,0 +1,8 @@
+package com.seiko.keystoreviewer.ads
+
+import android.content.Context
+import data.local.ExportQuota
+
+object ExportQuotaProvider {
+  fun quota(context: Context): ExportQuota = AdExportQuota(context)
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,6 +32,7 @@ okio = { module = "com.squareup.okio:okio", version = "3.18.2" }
 material-kolor = { module = "com.materialkolor:material-kolor", version = "5.0.1" }
 
 play-services-ads = { module = "com.google.android.gms:play-services-ads", version = "25.4.0" }
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version = "1.9.0" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }

--- a/shared/src/androidMain/kotlin/export/SignatureReportExporter.kt
+++ b/shared/src/androidMain/kotlin/export/SignatureReportExporter.kt
@@ -1,0 +1,74 @@
+package export
+
+import android.content.Context
+import android.net.Uri
+import data.model.AppSignature
+import data.model.from
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okio.ByteString
+import util.getUserInstalledAppInfos
+import util.signaturesCompat
+import util.versionCodeCompat
+
+/**
+ * 批量导出全部用户应用的签名报告(CSV,每行一个签名)。
+ */
+object SignatureReportExporter {
+
+  private val csvHeader = listOf(
+    "App Name",
+    "Package Name",
+    "Version Name",
+    "Version Code",
+    "Signer Index",
+    "MD5",
+    "SHA1",
+    "SHA256",
+  )
+
+  suspend fun buildCsv(context: Context): String = withContext(Dispatchers.IO) {
+    val packageManager = context.packageManager
+    val rows = mutableListOf(csvHeader.joinToString(","))
+    context.getUserInstalledAppInfos()
+      .map { packageInfo ->
+        val label = packageInfo.applicationInfo
+          ?.loadLabel(packageManager)?.toString().orEmpty()
+        packageInfo to label
+      }
+      .sortedBy { it.second.lowercase() }
+      .forEach { (packageInfo, name) ->
+        val versionName = csvEscape(packageInfo.versionName ?: "")
+        val versionCode = packageInfo.versionCodeCompat
+        packageInfo.signaturesCompat.forEachIndexed { index, signature ->
+          val bytes = ByteString.of(*AppSignature.from(signature).byteArray)
+          rows += listOf(
+            csvEscape(name),
+            csvEscape(packageInfo.packageName),
+            versionName,
+            versionCode.toString(),
+            index.toString(),
+            bytes.md5().hex(),
+            bytes.sha1().hex(),
+            bytes.sha256().hex(),
+          ).joinToString(",")
+        }
+      }
+    rows.joinToString("\r\n")
+  }
+
+  fun write(context: Context, uri: Uri, content: String): Boolean = runCatching {
+    context.contentResolver.openOutputStream(uri, "wt")?.use { stream ->
+      stream.write(content.toByteArray(Charsets.UTF_8))
+    } ?: return false
+    true
+  }.getOrDefault(false)
+
+  private fun csvEscape(value: String): String = if (value.contains(',') || value.contains('"') || value.contains('\n')) {
+    "\"${value.replace("\"", "\"\"")}\""
+  } else {
+    value
+  }
+}
+
+private fun okio.ByteString.hex(): String = toByteArray().joinToString("") { "%02x".format(it) }

--- a/shared/src/androidMain/kotlin/ui/screen/AppListScreen.kt
+++ b/shared/src/androidMain/kotlin/ui/screen/AppListScreen.kt
@@ -3,9 +3,12 @@ package ui.screen
 import android.Manifest
 import android.content.Context
 import android.os.Build
+import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -21,11 +24,16 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.FileDownload
+import androidx.compose.material.icons.filled.History
+import androidx.compose.material.icons.filled.Star
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
@@ -35,8 +43,10 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -44,6 +54,9 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import data.local.LocalExportQuota
+import data.local.LocalFavoritesRepository
+import data.local.LocalHistoryRepository
 import data.model.SignSource
 import data.model.UiAppInfo
 import kotlinx.coroutines.Dispatchers
@@ -57,7 +70,11 @@ import ui.widget.PermissionRequestContent
 import util.getFilePathFromUri
 
 @Composable
-fun AppListScreen(onItemClick: (SignSource) -> Unit) {
+fun AppListScreen(
+  onItemClick: (SignSource) -> Unit,
+  onOpenHistory: () -> Unit = {},
+  onOpenFavorites: () -> Unit = {},
+) {
   val context = LocalContext.current
 
   val scope = rememberCoroutineScope()
@@ -92,6 +109,10 @@ fun AppListScreen(onItemClick: (SignSource) -> Unit) {
       }
     },
   ) { innerPadding ->
+    var showExportSheet by remember { mutableStateOf(false) }
+    if (showExportSheet) {
+      ExportSheet(onDismiss = { showExportSheet = false })
+    }
     PermissionRequestContent(
       permissions = remember {
         buildList {
@@ -112,6 +133,9 @@ fun AppListScreen(onItemClick: (SignSource) -> Unit) {
         innerPadding = innerPadding,
         state = state,
         context = context,
+        onOpenHistory = onOpenHistory,
+        onOpenFavorites = onOpenFavorites,
+        onExportClick = { showExportSheet = true },
         onEvent = { event ->
           when (event) {
             is AppListScreenEvent.OnItemClick -> {
@@ -133,9 +157,15 @@ private fun AppListContent(
   innerPadding: PaddingValues,
   state: AppListScreenState,
   onEvent: (AppListScreenEvent) -> Unit,
+  onOpenHistory: () -> Unit,
+  onOpenFavorites: () -> Unit,
+  onExportClick: () -> Unit,
   modifier: Modifier = Modifier,
   context: Context = LocalContext.current,
 ) {
+  val scope = rememberCoroutineScope()
+  val historyRepository = LocalHistoryRepository.current
+  val favoritesRepository = LocalFavoritesRepository.current
   Column(
     modifier = modifier,
   ) {
@@ -168,6 +198,7 @@ private fun AppListContent(
       modifier = Modifier
         .padding(horizontal = 16.dp)
         .fillMaxWidth(),
+      verticalAlignment = Alignment.CenterVertically,
     ) {
       SelectButton(
         onClick = { onEvent(AppListScreenEvent.OnAppTypeChanged(AppType.User)) },
@@ -175,13 +206,32 @@ private fun AppListContent(
         text = "User",
         modifier = Modifier.weight(1f),
       )
-      Spacer(Modifier.width(16.dp))
+      Spacer(Modifier.width(12.dp))
       SelectButton(
         onClick = { onEvent(AppListScreenEvent.OnAppTypeChanged(AppType.System)) },
         selected = state.appType == AppType.System,
         text = "System",
         modifier = Modifier.weight(1f),
       )
+      Spacer(Modifier.width(12.dp))
+      IconButton(onClick = onExportClick) {
+        Icon(
+          Icons.Filled.FileDownload,
+          contentDescription = "export report",
+        )
+      }
+      IconButton(onClick = onOpenHistory) {
+        Icon(
+          Icons.Filled.History,
+          contentDescription = "history",
+        )
+      }
+      IconButton(onClick = onOpenFavorites) {
+        Icon(
+          Icons.Filled.Star,
+          contentDescription = "favorites",
+        )
+      }
     }
 
     LazyColumn(
@@ -212,7 +262,16 @@ private fun AppListContent(
               AppItem(
                 item = appInfo,
                 onClick = {
+                  scope.launch {
+                    historyRepository.record(appInfo.packageName, appInfo.name)
+                  }
                   onEvent(AppListScreenEvent.OnItemClick(appInfo.packageName))
+                },
+                onLongClick = {
+                  scope.launch {
+                    favoritesRepository.toggle(appInfo.packageName, appInfo.name)
+                  }
+                  Toast.makeText(context, "Favorites updated", Toast.LENGTH_SHORT).show()
                 },
                 context = context,
               )
@@ -268,18 +327,22 @@ private fun SelectButton(
   }
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun AppItem(
   item: UiAppInfo,
   onClick: () -> Unit,
   modifier: Modifier = Modifier,
   context: Context = LocalContext.current,
+  onLongClick: () -> Unit = {},
 ) {
   Surface(
-    onClick = onClick,
     shape = MaterialTheme.shapes.medium,
     tonalElevation = 1.dp,
-    modifier = modifier,
+    modifier = modifier.combinedClickable(
+      onClick = onClick,
+      onLongClick = onLongClick,
+    ),
   ) {
     AppListItem(
       leadingContent = {
@@ -337,6 +400,9 @@ private fun AppListContentPreview() {
           eventSink = {},
         ),
         onEvent = {},
+        onOpenHistory = {},
+        onOpenFavorites = {},
+        onExportClick = {},
       )
     }
   }

--- a/shared/src/androidMain/kotlin/ui/screen/ExportSheet.kt
+++ b/shared/src/androidMain/kotlin/ui/screen/ExportSheet.kt
@@ -1,0 +1,176 @@
+package ui.screen
+
+import android.content.Context
+import android.net.Uri
+import android.widget.Toast
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import data.local.LocalExportQuota
+import export.SignatureReportExporter
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import platform.ads.AdSlot
+import platform.ads.LocalAdSlot
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+/**
+ * 批量导出签名报告的弹层。
+ * play 变体:每天 2 次免费,看完激励广告 +2 次;foss 变体:UnlimitedExportQuota 完全免费。
+ */
+@Composable
+fun ExportSheet(
+  onDismiss: () -> Unit,
+  modifier: Modifier = Modifier,
+  context: Context = LocalContext.current,
+) {
+  val quota = LocalExportQuota.current
+  val adSlot = LocalAdSlot.current
+  val scope = rememberCoroutineScope()
+  val remaining by quota.remaining.collectAsState(null)
+  var offerRewarded by remember { mutableStateOf(false) }
+
+  val launcher = rememberLauncherForActivityResult(
+    remember { ActivityResultContracts.CreateDocument("text/csv") },
+  ) { uri: Uri? ->
+    if (uri != null) {
+      scope.launch {
+        val csv = SignatureReportExporter.buildCsv(context)
+        val ok = withContext(Dispatchers.IO) {
+          SignatureReportExporter.write(context, uri, csv)
+        }
+        Toast.makeText(
+          context,
+          if (ok) "Report saved" else "Failed to save report",
+          Toast.LENGTH_SHORT,
+        ).show()
+      }
+    }
+    onDismiss()
+  }
+
+  fun exportNow() = launcher.launch(
+    "keystoreviewer-signatures-" + SimpleDateFormat(
+      "yyyyMMdd-HHmm",
+      Locale.US,
+    ).format(Date()) + ".csv",
+  )
+
+  AlertDialog(
+    onDismissRequest = onDismiss,
+    modifier = modifier,
+    title = {
+      Text("Export signature report")
+    },
+    text = {
+      Column(
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+        modifier = Modifier.fillMaxWidth(),
+      ) {
+        Text(
+          "Export MD5 / SHA1 / SHA256 of all installed apps as a CSV file.",
+          style = MaterialTheme.typography.bodyMedium,
+        )
+        when (val left = remaining) {
+          null -> CircularProgressIndicator()
+
+          else -> Text(
+            "Remaining exports today: $left",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.primary,
+          )
+        }
+        if (adSlot.canShowRewarded()) {
+          Text(
+            "Watch a short ad to get +${AdSlot.REWARD_BONUS_COUNT} exports.",
+            style = MaterialTheme.typography.bodySmall,
+          )
+        }
+      }
+    },
+    confirmButton = {
+      Button(
+        onClick = {
+          scope.launch {
+            if (quota.tryConsume()) {
+              exportNow()
+            } else {
+              offerRewarded = true
+            }
+          }
+        },
+        enabled = remaining?.let { it > 0 || adSlot.canShowRewarded() } ?: false,
+      ) {
+        Text("Export CSV")
+      }
+    },
+    dismissButton = {
+      TextButton(onClick = onDismiss) {
+        Text("Cancel")
+      }
+    },
+  )
+
+  if (offerRewarded) {
+    AlertDialog(
+      onDismissRequest = { offerRewarded = false },
+      title = {
+        Text("Out of free exports")
+      },
+      text = {
+        Text(
+          "You have used up today's free exports. Watch a short ad to get " +
+            "+${AdSlot.REWARD_BONUS_COUNT} more exports.",
+        )
+      },
+      confirmButton = {
+        TextButton(
+          onClick = {
+            offerRewarded = false
+            adSlot.showRewarded("export_report") { rewarded ->
+              if (rewarded) {
+                scope.launch {
+                  quota.addBonus(AdSlot.REWARD_BONUS_COUNT)
+                  if (quota.tryConsume()) {
+                    exportNow()
+                  }
+                }
+              } else {
+                Toast.makeText(context, "Ad not finished", Toast.LENGTH_SHORT).show()
+              }
+            }
+          },
+        ) {
+          Text("Watch ad")
+        }
+      },
+      dismissButton = {
+        TextButton(onClick = { offerRewarded = false }) {
+          Text("Cancel")
+        }
+      },
+    )
+  }
+}

--- a/shared/src/commonMain/kotlin/data/local/AppData.kt
+++ b/shared/src/commonMain/kotlin/data/local/AppData.kt
@@ -1,0 +1,89 @@
+package data.local
+
+import androidx.compose.runtime.staticCompositionLocalOf
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class HistoryEntry(
+  val packageName: String,
+  val displayName: String,
+  val viewedAtMillis: Long,
+)
+
+interface HistoryRepository {
+  val entries: Flow<List<HistoryEntry>>
+
+  suspend fun record(packageName: String, displayName: String)
+
+  suspend fun remove(packageName: String)
+
+  suspend fun clear()
+}
+
+@Serializable
+data class FavoriteEntry(
+  val packageName: String,
+  val displayName: String,
+  val addedAtMillis: Long,
+)
+
+interface FavoritesRepository {
+  /** Ordered by latest added first. */
+  val entries: Flow<List<FavoriteEntry>>
+
+  suspend fun toggle(packageName: String, displayName: String)
+
+  suspend fun contains(packageName: String): Boolean
+
+  suspend fun remove(packageName: String)
+}
+
+/**
+ * 导出次数配额。免费额度按天重置,看激励广告可获得额外次数。
+ * 无广告能力的构建(F-Droid / GitHub Release / Desktop)默认 [UnlimitedExportQuota]:
+ * 功能完全免费,与激励广告的解锁逻辑天然兼容。
+ */
+interface ExportQuota {
+  val remaining: Flow<Int>
+
+  /** @return true 表示消耗一次成功,允许导出 */
+  suspend fun tryConsume(): Boolean
+
+  suspend fun addBonus(count: Int)
+}
+
+data object UnlimitedExportQuota : ExportQuota {
+  override val remaining: Flow<Int> = flowOf(Int.MAX_VALUE)
+
+  override suspend fun tryConsume(): Boolean = true
+
+  override suspend fun addBonus(count: Int) = Unit
+}
+
+data object EmptyHistoryRepository : HistoryRepository {
+  override val entries: Flow<List<HistoryEntry>> = flowOf(emptyList())
+
+  override suspend fun record(packageName: String, displayName: String) = Unit
+
+  override suspend fun remove(packageName: String) = Unit
+
+  override suspend fun clear() = Unit
+}
+
+data object EmptyFavoritesRepository : FavoritesRepository {
+  override val entries: Flow<List<FavoriteEntry>> = flowOf(emptyList())
+
+  override suspend fun toggle(packageName: String, displayName: String) = Unit
+
+  override suspend fun contains(packageName: String): Boolean = false
+
+  override suspend fun remove(packageName: String) = Unit
+}
+
+val LocalHistoryRepository = staticCompositionLocalOf<HistoryRepository> { EmptyHistoryRepository }
+
+val LocalFavoritesRepository = staticCompositionLocalOf<FavoritesRepository> { EmptyFavoritesRepository }
+
+val LocalExportQuota = staticCompositionLocalOf<ExportQuota> { UnlimitedExportQuota }

--- a/shared/src/commonMain/kotlin/platform/ads/AdSlot.kt
+++ b/shared/src/commonMain/kotlin/platform/ads/AdSlot.kt
@@ -12,6 +12,13 @@ import androidx.compose.ui.Modifier
  * 广告 SDK 依赖与代码对 foss 构建物理不可见。
  */
 interface AdSlot {
+
+  companion object {
+
+    /** 看一次激励广告获得的导出次数 */
+    const val REWARD_BONUS_COUNT = 2
+  }
+
   @Composable fun Banner(modifier: Modifier = Modifier)
 
   @Composable fun InlineNative(modifier: Modifier = Modifier)
@@ -23,6 +30,9 @@ interface AdSlot {
    * [onResult] 的参数表示用户是否完整看完并获得奖励。
    */
   fun showRewarded(placement: String, onResult: (rewarded: Boolean) -> Unit)
+
+  /** 当前变体是否具备激励广告能力(F-Droid 等无广告构建为 false) */
+  fun canShowRewarded(): Boolean
 }
 
 data object NoAdSlot : AdSlot {
@@ -33,6 +43,8 @@ data object NoAdSlot : AdSlot {
   override fun maybeShowInterstitial(placement: String) = Unit
 
   override fun showRewarded(placement: String, onResult: (rewarded: Boolean) -> Unit) = onResult(false)
+
+  override fun canShowRewarded(): Boolean = false
 }
 
 val LocalAdSlot = staticCompositionLocalOf<AdSlot> { NoAdSlot }

--- a/shared/src/commonMain/kotlin/ui/screen/FavoritesScreen.kt
+++ b/shared/src/commonMain/kotlin/ui/screen/FavoritesScreen.kt
@@ -1,0 +1,135 @@
+package ui.screen
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import data.local.FavoriteEntry
+import data.local.LocalFavoritesRepository
+import kotlinx.coroutines.launch
+import ui.widget.AppListItem
+import java.text.DateFormat
+import java.util.Date
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun FavoritesScreen(
+  onBack: () -> Unit,
+  onOpen: (packageName: String) -> Unit,
+) {
+  val repository = LocalFavoritesRepository.current
+  val entries by repository.entries.collectAsState(emptyList())
+  val scope = rememberCoroutineScope()
+
+  Scaffold(
+    topBar = {
+      TopAppBar(
+        navigationIcon = {
+          IconButton(onClick = onBack) {
+            Icon(
+              Icons.AutoMirrored.Filled.ArrowBack,
+              contentDescription = "back",
+            )
+          }
+        },
+        title = {
+          Text("Favorites")
+        },
+      )
+    },
+  ) { innerPadding ->
+    if (entries.isEmpty()) {
+      Box(
+        modifier = Modifier
+          .padding(innerPadding)
+          .fillMaxSize(),
+        contentAlignment = Alignment.Center,
+      ) {
+        Text(
+          "Long press an app in the list to add it to favorites",
+          style = MaterialTheme.typography.bodyMedium,
+          modifier = Modifier.padding(horizontal = 32.dp),
+        )
+      }
+    } else {
+      LazyColumn(
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+        modifier = Modifier
+          .padding(innerPadding)
+          .fillMaxSize(),
+        contentPadding = PaddingValues(16.dp),
+      ) {
+        items(
+          entries,
+          key = { it.packageName },
+        ) { entry ->
+          FavoriteItem(
+            entry = entry,
+            onClick = { onOpen(entry.packageName) },
+            onRemove = { scope.launch { repository.remove(entry.packageName) } },
+          )
+        }
+      }
+    }
+  }
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun FavoriteItem(
+  entry: FavoriteEntry,
+  onClick: () -> Unit,
+  onRemove: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  Surface(
+    shape = MaterialTheme.shapes.medium,
+    tonalElevation = 1.dp,
+    modifier = modifier.combinedClickable(
+      onClick = onClick,
+      onLongClick = onRemove,
+    ),
+  ) {
+    AppListItem(
+      leadingContent = {
+        Icon(
+          Icons.Filled.Star,
+          contentDescription = null,
+          tint = MaterialTheme.colorScheme.primary,
+        )
+      },
+      headlineContent = {
+        Text(entry.displayName)
+      },
+      supportingContent = {
+        Text(entry.packageName)
+      },
+      modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+    )
+  }
+}

--- a/shared/src/commonMain/kotlin/ui/screen/HistoryScreen.kt
+++ b/shared/src/commonMain/kotlin/ui/screen/HistoryScreen.kt
@@ -1,0 +1,142 @@
+package ui.screen
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.DeleteSweep
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import data.local.HistoryEntry
+import data.local.LocalHistoryRepository
+import kotlinx.coroutines.launch
+import ui.widget.AppListItem
+import java.text.DateFormat
+import java.util.Date
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun HistoryScreen(
+  onBack: () -> Unit,
+  onOpen: (packageName: String) -> Unit,
+) {
+  val repository = LocalHistoryRepository.current
+  val entries by repository.entries.collectAsState(emptyList())
+  val scope = rememberCoroutineScope()
+
+  Scaffold(
+    topBar = {
+      TopAppBar(
+        navigationIcon = {
+          IconButton(onClick = onBack) {
+            Icon(
+              Icons.AutoMirrored.Filled.ArrowBack,
+              contentDescription = "back",
+            )
+          }
+        },
+        title = {
+          Text("History")
+        },
+        actions = {
+          if (entries.isNotEmpty()) {
+            IconButton(
+              onClick = { scope.launch { repository.clear() } },
+            ) {
+              Icon(
+                Icons.Filled.DeleteSweep,
+                contentDescription = "clear history",
+              )
+            }
+          }
+        },
+      )
+    },
+  ) { innerPadding ->
+    if (entries.isEmpty()) {
+      Box(
+        modifier = Modifier
+          .padding(innerPadding)
+          .fillMaxSize(),
+        contentAlignment = Alignment.Center,
+      ) {
+        Text(
+          "No history yet",
+          style = MaterialTheme.typography.bodyMedium,
+        )
+      }
+    } else {
+      LazyColumn(
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+        modifier = Modifier
+          .padding(innerPadding)
+          .fillMaxSize(),
+        contentPadding = PaddingValues(16.dp),
+      ) {
+        items(
+          entries,
+          key = { it.packageName },
+        ) { entry ->
+          HistoryItem(
+            entry = entry,
+            onClick = { onOpen(entry.packageName) },
+            onRemove = { scope.launch { repository.remove(entry.packageName) } },
+          )
+        }
+      }
+    }
+  }
+}
+
+@Composable
+private fun HistoryItem(
+  entry: HistoryEntry,
+  onClick: () -> Unit,
+  onRemove: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  Surface(
+    onClick = onClick,
+    shape = MaterialTheme.shapes.medium,
+    tonalElevation = 1.dp,
+    modifier = modifier,
+  ) {
+    AppListItem(
+      headlineContent = {
+        Text(entry.displayName)
+      },
+      supportingContent = {
+        Text(entry.packageName)
+      },
+      trailingContent = {
+        Text(
+          DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.SHORT)
+            .format(Date(entry.viewedAtMillis)),
+          style = MaterialTheme.typography.labelSmall,
+        )
+      },
+      modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+    )
+  }
+}


### PR DESCRIPTION
## Summary (Phase M2 of monetization plan)
- **History & Favorites**: local persistence, dedicated screens, auto-record on open, long-press to favorite
- **Batch export**: CSV report (per-signer MD5/SHA1/SHA256, lowercase, Excel-friendly) via SAF — no storage permission
- **Rewarded gate**: 2 free exports/day, watch rewarded ad for +2 (play flavor); foss/desktop are unlimited and ad-free by design (gate logic auto-grants when ad capability is absent)
- Storage via kotlinx-serialization JSON files; abstractions live in shared so desktop is unaffected

## Verification
- assembleFossRelease / assemblePlayRelease / debug / desktop compile ✅
- spotlessCheck ✅
- foss debug dex: 0 × `com.google.android.gms.ads` ✅