### PR TITLE
feat: rewarded-only ad strategy with UMP consent and ready-state UX

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -129,6 +129,7 @@ dependencies {
   implementation(projects.shared)
   implementation(libs.kotlinx.serialization.json)
   "playImplementation"(libs.play.services.ads)
+  "playImplementation"(libs.user.messaging.platform)
   implementation(libs.androidx.activity.compose)
   implementation(libs.navigation3.runtime)
   implementation(libs.navigation3.ui)

--- a/androidApp/src/play/kotlin/com/seiko/keystoreviewer/ads/AdmobAdSlot.kt
+++ b/androidApp/src/play/kotlin/com/seiko/keystoreviewer/ads/AdmobAdSlot.kt
@@ -15,12 +15,15 @@ import com.google.android.gms.ads.MobileAds
 import com.google.android.gms.ads.rewarded.RewardedAd
 import com.google.android.gms.ads.rewarded.RewardedAdLoadCallback
 import com.seiko.keystoreviewer.BuildConfig
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import platform.ads.AdSlot
 import java.lang.ref.WeakReference
 
 /**
- * M1 阶段 Banner 使用 Google 官方测试 ID;正式 banner/native/interstitial ID 在 M3 接入。
- * Rewarded ID 经 play 变体 BuildConfig 注入(不入 git)。
+ * play 变体唯一广告形式:激励广告(用户主动看广告换导出次数)。
+ * Banner/Native/Interstitial 已在产品决策中移除,保持简单 app 的克制。
  */
 object AdmobAdSlot : AdSlot {
 
@@ -31,10 +34,18 @@ object AdmobAdSlot : AdSlot {
   private var rewardedAd: RewardedAd? = null
   private var rewardEarned = false
 
+  private val rewardedReadyFlow = MutableStateFlow(false)
+  override val isRewardedReady: StateFlow<Boolean> = rewardedReadyFlow.asStateFlow()
+
   fun onActivityCreated(activity: Activity) {
     activityRef = WeakReference(activity)
     appContext = activity.applicationContext
-    MobileAds.initialize(activity) {}
+  }
+
+  /** 在 UMP 同意流程完成后调用 */
+  fun initializeAds() {
+    val context = appContext ?: return
+    MobileAds.initialize(context) {}
     preloadRewarded()
   }
 
@@ -69,12 +80,14 @@ object AdmobAdSlot : AdSlot {
     ad.fullScreenContentCallback = object : FullScreenContentCallback() {
       override fun onAdDismissedFullScreenContent() {
         rewardedAd = null
+        rewardedReadyFlow.value = false
         onResult(rewardEarned)
         preloadRewarded()
       }
 
       override fun onAdFailedToShowFullScreenContent(error: AdError) {
         rewardedAd = null
+        rewardedReadyFlow.value = false
         onResult(false)
         preloadRewarded()
       }
@@ -93,6 +106,7 @@ object AdmobAdSlot : AdSlot {
       object : RewardedAdLoadCallback() {
         override fun onAdLoaded(ad: RewardedAd) {
           rewardedAd = ad
+          rewardedReadyFlow.value = true
         }
       },
     )

--- a/androidApp/src/play/kotlin/com/seiko/keystoreviewer/ads/Ads.kt
+++ b/androidApp/src/play/kotlin/com/seiko/keystoreviewer/ads/Ads.kt
@@ -2,12 +2,37 @@ package com.seiko.keystoreviewer.ads
 
 import android.app.Activity
 import com.google.android.gms.ads.MobileAds
+import com.google.android.ump.ConsentRequestParameters
+import com.google.android.ump.UserMessagingPlatform
 import platform.ads.AdSlot
 
 object Ads {
+
+  private var adsInitialized = false
+
   fun initialize(activity: Activity) {
     AdmobAdSlot.onActivityCreated(activity)
-    MobileAds.initialize(activity) {}
+
+    val consentInformation = UserMessagingPlatform.getConsentInformation(activity)
+    consentInformation.requestConsentInfoUpdate(
+      activity,
+      ConsentRequestParameters.Builder().build(),
+      {
+        if (consentInformation.canRequestAds()) initAds(activity)
+      },
+      {
+        // 同意信息获取失败(如离线):不初始化广告,其余功能不受影响
+      },
+    )
+    // 上一会话已收集过同意时,无需等本次请求即可初始化
+    if (consentInformation.canRequestAds()) initAds(activity)
+  }
+
+  private fun initAds(activity: Activity) {
+    if (adsInitialized) return
+    adsInitialized = true
+    UserMessagingPlatform.loadAndShowConsentFormIfRequired(activity) {}
+    AdmobAdSlot.initializeAds()
   }
 
   fun slot(): AdSlot = AdmobAdSlot

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,6 +32,7 @@ okio = { module = "com.squareup.okio:okio", version = "3.18.2" }
 material-kolor = { module = "com.materialkolor:material-kolor", version = "5.0.1" }
 
 play-services-ads = { module = "com.google.android.gms:play-services-ads", version = "25.4.0" }
+user-messaging-platform = { module = "com.google.android.ump:user-messaging-platform", version = "4.0.0" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version = "1.9.0" }
 
 [plugins]

--- a/shared/src/androidMain/kotlin/ui/screen/ExportSheet.kt
+++ b/shared/src/androidMain/kotlin/ui/screen/ExportSheet.kt
@@ -50,6 +50,7 @@ fun ExportSheet(
   val adSlot = LocalAdSlot.current
   val scope = rememberCoroutineScope()
   val remaining by quota.remaining.collectAsState(null)
+  val rewardedReady by adSlot.isRewardedReady.collectAsState()
   var offerRewarded by remember { mutableStateOf(false) }
 
   val launcher = rememberLauncherForActivityResult(
@@ -121,7 +122,7 @@ fun ExportSheet(
             }
           }
         },
-        enabled = remaining?.let { it > 0 || adSlot.canShowRewarded() } ?: false,
+        enabled = remaining?.let { it > 0 || (adSlot.canShowRewarded() && rewardedReady) } ?: false,
       ) {
         Text("Export CSV")
       }
@@ -147,6 +148,7 @@ fun ExportSheet(
       },
       confirmButton = {
         TextButton(
+          enabled = rewardedReady,
           onClick = {
             offerRewarded = false
             adSlot.showRewarded("export_report") { rewarded ->
@@ -163,7 +165,7 @@ fun ExportSheet(
             }
           },
         ) {
-          Text("Watch ad")
+          Text(if (rewardedReady) "Watch ad" else "Loading ad…")
         }
       },
       dismissButton = {

--- a/shared/src/commonMain/kotlin/platform/ads/AdSlot.kt
+++ b/shared/src/commonMain/kotlin/platform/ads/AdSlot.kt
@@ -3,6 +3,8 @@ package platform.ads
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Modifier
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 
 /**
  * 广告展示能力的抽象。
@@ -33,6 +35,9 @@ interface AdSlot {
 
   /** 当前变体是否具备激励广告能力(F-Droid 等无广告构建为 false) */
   fun canShowRewarded(): Boolean
+
+  /** 激励广告是否已预加载就绪(用于控制按钮可用态) */
+  val isRewardedReady: StateFlow<Boolean>
 }
 
 data object NoAdSlot : AdSlot {
@@ -45,6 +50,8 @@ data object NoAdSlot : AdSlot {
   override fun showRewarded(placement: String, onResult: (rewarded: Boolean) -> Unit) = onResult(false)
 
   override fun canShowRewarded(): Boolean = false
+
+  override val isRewardedReady: StateFlow<Boolean> = MutableStateFlow(false)
 }
 
 val LocalAdSlot = staticCompositionLocalOf<AdSlot> { NoAdSlot }


### PR DESCRIPTION
## Summary
- Product decision: rewarded ads are the only format (highest eCPM, tasteful for a simple utility, play flavor only) — banner/native/interstitial plans cancelled
- UMP consent flow in play flavor (GDPR-compliant): consent gathered → `canRequestAds` → MobileAds init → rewarded preload
- `AdSlot.isRewardedReady`: the watch-ad button now disables with "Loading ad…" until the rewarded ad is preloaded, preventing dead-end taps

## Verification
- All variants build (foss/play × debug/release) + desktop + spotlessCheck ✅
- foss dex contains no ad SDK symbols (only androidx Photo Picker constant) ✅