### PR TITLE
feat: support Play-only in-app updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,4 +19,4 @@ jobs:
       - uses: gradle/actions/setup-gradle@v4
 
       - name: Check
-        run: ./gradlew spotlessCheck :shared:desktopTest :androidApp:assembleDebug :desktopApp:compileKotlin
+        run: ./gradlew spotlessCheck :shared:desktopTest :androidApp:testPlayDebugUnitTest :androidApp:assembleDebug :desktopApp:compileKotlin

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -132,6 +132,7 @@ kotlin {
 dependencies {
   implementation(projects.shared)
   implementation(libs.kotlinx.serialization.json)
+  "playImplementation"(libs.play.app.update)
   "playImplementation"(libs.play.services.ads)
   "playImplementation"(libs.user.messaging.platform)
   implementation(libs.androidx.activity.compose)
@@ -139,6 +140,7 @@ dependencies {
   implementation(libs.navigation3.ui)
   implementation(libs.androidx.navigationevent.compose)
   debugImplementation(libs.compose.ui.tooling)
+  testImplementation(libs.junit)
 }
 
 val gitCommit: String =

--- a/androidApp/src/foss/kotlin/com/seiko/keystoreviewer/update/StoreUpdatePrompt.kt
+++ b/androidApp/src/foss/kotlin/com/seiko/keystoreviewer/update/StoreUpdatePrompt.kt
@@ -1,0 +1,7 @@
+package com.seiko.keystoreviewer.update
+
+import androidx.compose.runtime.Composable
+
+/** FOSS updates are managed by the distribution channel; no Play SDK is linked. */
+@Composable
+fun StoreUpdatePrompt() = Unit

--- a/androidApp/src/main/kotlin/com/seiko/keystoreviewer/MainActivity.kt
+++ b/androidApp/src/main/kotlin/com/seiko/keystoreviewer/MainActivity.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
@@ -30,6 +31,7 @@ import com.seiko.keystoreviewer.ui.motion3.motion3PredictivePopTransitionSpec
 import com.seiko.keystoreviewer.ui.motion3.motion3TransitionSpec
 import com.seiko.keystoreviewer.ui.motion3.rememberMotion3
 import com.seiko.keystoreviewer.ui.motion3.rememberMotion3SceneDecoratorStrategy
+import com.seiko.keystoreviewer.update.StoreUpdatePrompt
 import data.local.FileFavoritesRepository
 import data.local.FileHistoryRepository
 import data.local.LocalExportQuota
@@ -205,7 +207,10 @@ private fun KeyStoreViewerApp() {
   Scaffold(
     contentWindowInsets = WindowInsets(0, 0, 0, 0),
     bottomBar = {
-      RootTabBar(selectedTab) { target -> backStack.selectRoot(AppList, rootDestinations.getValue(target)) }
+      Column {
+        StoreUpdatePrompt()
+        RootTabBar(selectedTab) { target -> backStack.selectRoot(AppList, rootDestinations.getValue(target)) }
+      }
     },
   ) { padding ->
     NavDisplay(

--- a/androidApp/src/play/kotlin/com/seiko/keystoreviewer/update/FlexibleUpdateController.kt
+++ b/androidApp/src/play/kotlin/com/seiko/keystoreviewer/update/FlexibleUpdateController.kt
@@ -1,0 +1,134 @@
+package com.seiko.keystoreviewer.update
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+internal enum class UpdateStatus { Idle, Pending, Downloading, Downloaded, Installing, Installed, Failed, Canceled }
+
+/** The optional consent action wraps a single-use AppUpdateInfo; never cache it across attempts. */
+internal data class UpdateOffer(val status: UpdateStatus, val launchConsent: (() -> Boolean)? = null)
+
+internal interface UpdateClient {
+  fun observe(listener: (UpdateStatus) -> Unit)
+  fun stopObserving()
+  fun check(result: (Result<UpdateOffer>) -> Unit)
+  fun complete(result: (Result<Unit>) -> Unit)
+}
+
+internal sealed interface UpdateUi {
+  data object Hidden : UpdateUi
+  data object Available : UpdateUi
+  data object Checking : UpdateUi
+  data object Ready : UpdateUi
+  data object Installing : UpdateUi
+  data class Error(val completing: Boolean) : UpdateUi
+}
+
+/** Main-thread controller; stale foreground/query callbacks cannot override newer install events. */
+internal class FlexibleUpdateController(private val client: UpdateClient) {
+  private val mutableState = MutableStateFlow<UpdateUi>(UpdateUi.Hidden)
+  val state = mutableState.asStateFlow()
+  private var active = false
+  private var generation = 0
+  private var revision = 0
+  private var availableDismissed = false
+  private var readyDismissed = false
+
+  fun resume() {
+    if (active) return
+    active = true
+    generation++
+    readyDismissed = false
+    val session = generation
+    client.observe { status ->
+      if (active && generation == session) {
+        revision++
+        showStatus(status)
+      }
+    }
+    check(manual = false)
+  }
+
+  fun pause() {
+    if (!active) return
+    active = false
+    generation++
+    client.stopObserving()
+    if (mutableState.value == UpdateUi.Checking) mutableState.value = UpdateUi.Hidden
+  }
+
+  fun dismiss() {
+    revision++ // A queued Later also cancels a manual check that has not launched consent yet.
+    availableDismissed = true
+    readyDismissed = true
+    mutableState.value = UpdateUi.Hidden
+  }
+
+  fun requestUpdate() {
+    if (!active) return
+    if (mutableState.value != UpdateUi.Available && mutableState.value != UpdateUi.Error(completing = false)) return
+    check(manual = true)
+  }
+
+  fun onConsentResult(accepted: Boolean, failed: Boolean = false) {
+    // Returning from Play must not immediately prompt again, or erase an already downloaded update.
+    availableDismissed = true
+    if (!accepted && mutableState.value != UpdateUi.Ready) {
+      mutableState.value = if (failed) UpdateUi.Error(completing = false) else UpdateUi.Hidden
+    }
+  }
+
+  fun restart() {
+    if (!active || mutableState.value != UpdateUi.Ready) return
+    mutableState.value = UpdateUi.Installing
+    val session = generation
+    client.complete { result ->
+      if (active && generation == session && result.isFailure) {
+        mutableState.value = UpdateUi.Error(completing = true)
+      }
+    }
+  }
+
+  fun retry() {
+    val error = mutableState.value as? UpdateUi.Error ?: return
+    if (error.completing) {
+      mutableState.value = UpdateUi.Ready
+      restart()
+    } else {
+      requestUpdate()
+    }
+  }
+
+  private fun check(manual: Boolean) {
+    if (manual) mutableState.value = UpdateUi.Checking
+    val session = generation
+    val request = ++revision
+    client.check callback@{ result ->
+      if (!active || generation != session || revision != request) return@callback
+      val offer = result.getOrNull()
+      if (offer == null) {
+        // No Play Store, offline, or sideloaded builds must never block ordinary app use.
+        if (manual) mutableState.value = UpdateUi.Error(completing = false)
+        return@callback
+      }
+      if (offer.status in setOf(UpdateStatus.Downloaded, UpdateStatus.Pending, UpdateStatus.Downloading, UpdateStatus.Installing, UpdateStatus.Installed)) {
+        showStatus(offer.status)
+      } else if (manual && offer.launchConsent != null) {
+        availableDismissed = true
+        mutableState.value = UpdateUi.Hidden
+        val launched = runCatching { offer.launchConsent.invoke() }.getOrDefault(false)
+        if (!launched) mutableState.value = UpdateUi.Error(completing = false)
+      } else {
+        mutableState.value = if (!availableDismissed && offer.launchConsent != null) UpdateUi.Available else UpdateUi.Hidden
+      }
+    }
+  }
+
+  private fun showStatus(status: UpdateStatus) {
+    mutableState.value = when (status) {
+      UpdateStatus.Downloaded -> if (readyDismissed) UpdateUi.Hidden else UpdateUi.Ready
+      UpdateStatus.Failed -> UpdateUi.Error(completing = false)
+      else -> UpdateUi.Hidden
+    }
+  }
+}

--- a/androidApp/src/play/kotlin/com/seiko/keystoreviewer/update/GooglePlayUpdateClient.kt
+++ b/androidApp/src/play/kotlin/com/seiko/keystoreviewer/update/GooglePlayUpdateClient.kt
@@ -1,0 +1,74 @@
+package com.seiko.keystoreviewer.update
+
+import android.content.Context
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.IntentSenderRequest
+import com.google.android.play.core.appupdate.AppUpdateManagerFactory
+import com.google.android.play.core.appupdate.AppUpdateOptions
+import com.google.android.play.core.install.InstallStateUpdatedListener
+import com.google.android.play.core.install.model.AppUpdateType
+import com.google.android.play.core.install.model.InstallStatus
+import com.google.android.play.core.install.model.UpdateAvailability
+
+internal class GooglePlayUpdateClient(
+  context: Context,
+  private val launcher: ActivityResultLauncher<IntentSenderRequest>,
+) : UpdateClient {
+  private val manager = AppUpdateManagerFactory.create(context.applicationContext)
+  private var listener: InstallStateUpdatedListener? = null
+
+  override fun observe(listener: (UpdateStatus) -> Unit) {
+    stopObserving()
+    val observer = InstallStateUpdatedListener { listener(it.installStatus().toUpdateStatus()) }
+    this.listener = observer
+    manager.registerListener(observer)
+  }
+
+  override fun stopObserving() {
+    listener?.let(manager::unregisterListener)
+    listener = null
+  }
+
+  override fun check(result: (Result<UpdateOffer>) -> Unit) {
+    runCatching {
+      manager.appUpdateInfo
+        .addOnSuccessListener { info ->
+          val launch = if (
+            info.updateAvailability() == UpdateAvailability.UPDATE_AVAILABLE &&
+            info.isUpdateTypeAllowed(AppUpdateType.FLEXIBLE)
+          ) {
+            {
+              manager.startUpdateFlowForResult(
+                info,
+                launcher,
+                AppUpdateOptions.newBuilder(AppUpdateType.FLEXIBLE).build(),
+              )
+            }
+          } else {
+            null
+          }
+          result(Result.success(UpdateOffer(info.installStatus().toUpdateStatus(), launch)))
+        }
+        .addOnFailureListener { result(Result.failure(it)) }
+    }.onFailure { result(Result.failure(it)) }
+  }
+
+  override fun complete(result: (Result<Unit>) -> Unit) {
+    runCatching {
+      manager.completeUpdate()
+        .addOnSuccessListener { result(Result.success(Unit)) }
+        .addOnFailureListener { result(Result.failure(it)) }
+    }.onFailure { result(Result.failure(it)) }
+  }
+}
+
+private fun Int.toUpdateStatus(): UpdateStatus = when (this) {
+  InstallStatus.PENDING -> UpdateStatus.Pending
+  InstallStatus.DOWNLOADING -> UpdateStatus.Downloading
+  InstallStatus.DOWNLOADED -> UpdateStatus.Downloaded
+  InstallStatus.INSTALLING -> UpdateStatus.Installing
+  InstallStatus.INSTALLED -> UpdateStatus.Installed
+  InstallStatus.FAILED -> UpdateStatus.Failed
+  InstallStatus.CANCELED -> UpdateStatus.Canceled
+  else -> UpdateStatus.Idle
+}

--- a/androidApp/src/play/kotlin/com/seiko/keystoreviewer/update/StoreUpdatePrompt.kt
+++ b/androidApp/src/play/kotlin/com/seiko/keystoreviewer/update/StoreUpdatePrompt.kt
@@ -1,0 +1,109 @@
+package com.seiko.keystoreviewer.update
+
+import android.app.Activity
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
+
+/** A non-modal prompt: neither startup nor returning from an ad/SAF launches Play consent. */
+@Composable
+fun StoreUpdatePrompt() {
+  val context = LocalContext.current
+  val lifecycle = LocalLifecycleOwner.current.lifecycle
+  var resultController by remember { mutableStateOf<FlexibleUpdateController?>(null) }
+  val launcher = rememberLauncherForActivityResult(ActivityResultContracts.StartIntentSenderForResult()) {
+    resultController?.onConsentResult(
+      accepted = it.resultCode == Activity.RESULT_OK,
+      failed = it.resultCode != Activity.RESULT_OK && it.resultCode != Activity.RESULT_CANCELED,
+    )
+  }
+  val controller = remember(context, launcher) {
+    FlexibleUpdateController(GooglePlayUpdateClient(context.applicationContext, launcher))
+  }
+  DisposableEffect(controller, lifecycle) {
+    resultController = controller
+    val observer = LifecycleEventObserver { _, event ->
+      when (event) {
+        Lifecycle.Event.ON_RESUME -> controller.resume()
+        Lifecycle.Event.ON_PAUSE -> controller.pause()
+        else -> Unit
+      }
+    }
+    lifecycle.addObserver(observer)
+    if (lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED)) controller.resume()
+    onDispose {
+      lifecycle.removeObserver(observer)
+      controller.pause()
+      resultController = null
+    }
+  }
+  val state by controller.state.collectAsState()
+  if (state == UpdateUi.Hidden) return
+  Surface(color = MaterialTheme.colorScheme.surface, modifier = Modifier.fillMaxWidth()) {
+    Column(
+      Modifier.windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal))
+        .padding(horizontal = 20.dp, vertical = 8.dp),
+    ) {
+      Text(
+        when (val value = state) {
+          UpdateUi.Available -> "An update is available on Google Play."
+          UpdateUi.Checking -> "Checking for an update…"
+          UpdateUi.Ready -> "Update downloaded. Restart to install when you're ready."
+          UpdateUi.Installing -> "Restarting to install the update…"
+          is UpdateUi.Error -> if (value.completing) "Couldn't install the update. Please try again." else "Couldn't update right now. Please try again later."
+          UpdateUi.Hidden -> ""
+        },
+        style = MaterialTheme.typography.bodyMedium,
+      )
+      if (state != UpdateUi.Checking && state != UpdateUi.Installing) {
+        FlowRow {
+          TextButton(
+            onClick = {
+              when (state) {
+                UpdateUi.Ready -> controller.restart()
+                is UpdateUi.Error -> controller.retry()
+                else -> controller.requestUpdate()
+              }
+            },
+            modifier = Modifier.heightIn(min = 48.dp),
+          ) {
+            Text(
+              when (state) {
+                UpdateUi.Ready -> "Restart"
+                is UpdateUi.Error -> "Retry"
+                else -> "Update"
+              },
+            )
+          }
+          TextButton(onClick = controller::dismiss, modifier = Modifier.heightIn(min = 48.dp)) { Text("Later") }
+        }
+      }
+    }
+  }
+}

--- a/androidApp/src/testPlay/kotlin/com/seiko/keystoreviewer/update/FlexibleUpdateControllerTest.kt
+++ b/androidApp/src/testPlay/kotlin/com/seiko/keystoreviewer/update/FlexibleUpdateControllerTest.kt
@@ -1,0 +1,230 @@
+package com.seiko.keystoreviewer.update
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class FlexibleUpdateControllerTest {
+  private val client = FakeClient()
+  private val controller = FlexibleUpdateController(client)
+  private var launches = 0
+  private fun offer(status: UpdateStatus = UpdateStatus.Idle, succeeds: Boolean = true) = UpdateOffer(status) {
+    launches++
+    succeeds
+  }
+
+  @Test fun availabilityNeverLaunchesConsentAutomatically() {
+    controller.resume()
+    client.answer(0, offer())
+    assertEquals(UpdateUi.Available, controller.state.value)
+    assertEquals(0, launches)
+  }
+
+  @Test fun tapRequestsFreshInfoAndDeduplicatesDoubleTap() {
+    controller.resume()
+    client.answer(0, offer())
+    controller.requestUpdate()
+    controller.requestUpdate()
+    assertEquals(2, client.checks.size)
+    assertEquals(0, launches)
+    client.answer(1, offer())
+    assertEquals(1, launches)
+    assertEquals(UpdateUi.Hidden, controller.state.value)
+  }
+
+  @Test fun unavailableOrDisallowedUpdateStaysHidden() {
+    controller.resume()
+    client.answer(0, UpdateOffer(UpdateStatus.Idle))
+    assertEquals(UpdateUi.Hidden, controller.state.value)
+    assertEquals(0, launches)
+  }
+
+  @Test fun noPlayOrNetworkFailureDoesNotBlockTheApp() {
+    controller.resume()
+    client.checks[0](Result.failure(IllegalStateException("Unavailable")))
+    assertEquals(UpdateUi.Hidden, controller.state.value)
+  }
+
+  @Test fun laterAndCancelDoNotRepromptOnResume() {
+    controller.resume()
+    client.answer(0, offer())
+    controller.dismiss()
+    controller.pause()
+    controller.resume()
+    client.answer(1, offer())
+    assertEquals(UpdateUi.Hidden, controller.state.value)
+    controller.onConsentResult(false)
+    assertEquals(0, launches)
+  }
+
+  @Test fun playConsentFailureOffersRetryInsteadOfTreatingItAsCancellation() {
+    controller.resume()
+    client.answer(0, offer())
+    controller.requestUpdate()
+    client.answer(1, offer())
+    controller.onConsentResult(accepted = false, failed = true)
+    assertEquals(UpdateUi.Error(false), controller.state.value)
+    controller.retry()
+    assertEquals(3, client.checks.size)
+  }
+
+  @Test fun downloadedOnResumeRequiresExplicitRestart() {
+    controller.resume()
+    client.answer(0, offer(UpdateStatus.Downloaded))
+    assertEquals(UpdateUi.Ready, controller.state.value)
+    assertEquals(0, client.completions.size)
+    assertEquals(0, launches)
+    controller.restart()
+    controller.restart()
+    assertEquals(1, client.completions.size)
+    assertEquals(UpdateUi.Installing, controller.state.value)
+  }
+
+  @Test fun downloadedLaterIsOfferedOnNextForeground() {
+    controller.resume()
+    client.answer(0, UpdateOffer(UpdateStatus.Downloaded))
+    controller.dismiss()
+    client.listener!!(UpdateStatus.Downloaded)
+    assertEquals(UpdateUi.Hidden, controller.state.value)
+    controller.pause()
+    controller.resume()
+    client.answer(1, UpdateOffer(UpdateStatus.Downloaded))
+    assertEquals(UpdateUi.Ready, controller.state.value)
+  }
+
+  @Test fun backgroundDownloadDoesNotLaunchOrRestartAnything() {
+    controller.resume()
+    client.answer(0, offer(UpdateStatus.Downloading))
+    client.listener!!(UpdateStatus.Downloaded)
+    assertEquals(UpdateUi.Ready, controller.state.value)
+    controller.onConsentResult(true)
+    assertEquals(UpdateUi.Ready, controller.state.value)
+    assertEquals(0, launches)
+    assertTrue(client.completions.isEmpty())
+  }
+
+  @Test fun newerDownloadEventWinsOverOldCheck() {
+    controller.resume()
+    client.listener!!(UpdateStatus.Downloaded)
+    client.answer(0, offer())
+    assertEquals(UpdateUi.Ready, controller.state.value)
+  }
+
+  @Test fun listenerAndCallbacksAreBoundToForegroundLifetime() {
+    controller.resume()
+    controller.resume()
+    assertEquals(1, client.registrations)
+    val oldListener = client.listener!!
+    controller.pause()
+    controller.pause()
+    assertEquals(1, client.unregistrations)
+    client.answer(0, offer())
+    oldListener(UpdateStatus.Downloaded)
+    assertEquals(UpdateUi.Hidden, controller.state.value)
+    controller.resume()
+    oldListener(UpdateStatus.Downloaded)
+    client.answer(1, UpdateOffer(UpdateStatus.Idle))
+    assertEquals(UpdateUi.Hidden, controller.state.value)
+  }
+
+  @Test fun failedLaunchRetryUsesAnotherOffer() {
+    controller.resume()
+    client.answer(0, offer())
+    controller.requestUpdate()
+    client.answer(1, offer(succeeds = false))
+    assertEquals(UpdateUi.Error(false), controller.state.value)
+    controller.retry()
+    assertEquals(3, client.checks.size)
+    client.answer(2, offer())
+    assertEquals(2, launches)
+  }
+
+  @Test fun downloadFailureCanRetryWithNewEligibleOffer() {
+    controller.resume()
+    client.answer(0, offer(UpdateStatus.Downloading))
+    client.listener!!(UpdateStatus.Failed)
+    controller.retry()
+    client.answer(1, offer(UpdateStatus.Failed))
+    assertEquals(1, launches)
+  }
+
+  @Test fun completionFailureCanRetryButNeverInstallsWhilePaused() {
+    controller.resume()
+    client.answer(0, UpdateOffer(UpdateStatus.Downloaded))
+    controller.restart()
+    client.completions[0](Result.failure(IllegalStateException("Install failed")))
+    assertEquals(UpdateUi.Error(true), controller.state.value)
+    controller.retry()
+    assertEquals(2, client.completions.size)
+    controller.pause()
+    controller.restart()
+    assertEquals(2, client.completions.size)
+  }
+
+  @Test fun manualCheckFailureIsRetryableAndStaleRequestCannotOverwriteIt() {
+    controller.resume()
+    client.answer(0, offer())
+    controller.pause()
+    controller.resume()
+    controller.requestUpdate()
+    client.checks[2](Result.failure(IllegalStateException("Offline")))
+    client.answer(1, offer())
+    assertEquals(UpdateUi.Error(false), controller.state.value)
+    controller.retry()
+    assertEquals(4, client.checks.size)
+  }
+
+  @Test fun queuedTapAfterConsentLaunchDoesNotStartAnotherAttempt() {
+    controller.resume()
+    client.answer(0, offer())
+    controller.requestUpdate()
+    client.answer(1, offer())
+    controller.requestUpdate()
+    assertEquals(2, client.checks.size)
+    assertEquals(1, launches)
+  }
+
+  @Test fun laterCancelsInFlightManualCheck() {
+    controller.resume()
+    client.answer(0, offer())
+    controller.requestUpdate()
+    controller.dismiss()
+    client.answer(1, offer())
+    assertEquals(UpdateUi.Hidden, controller.state.value)
+    assertEquals(0, launches)
+  }
+
+  @Test fun downloadedBetweenBannerAndTapDoesNotLaunchConsentAgain() {
+    controller.resume()
+    client.answer(0, offer())
+    controller.requestUpdate()
+    client.answer(1, offer(UpdateStatus.Downloaded))
+    assertEquals(UpdateUi.Ready, controller.state.value)
+    assertEquals(0, launches)
+  }
+
+  private class FakeClient : UpdateClient {
+    var listener: ((UpdateStatus) -> Unit)? = null
+    var registrations = 0
+    var unregistrations = 0
+    val checks = mutableListOf<(Result<UpdateOffer>) -> Unit>()
+    val completions = mutableListOf<(Result<Unit>) -> Unit>()
+    override fun observe(listener: (UpdateStatus) -> Unit) {
+      registrations++
+      this.listener = listener
+    }
+    override fun stopObserving() {
+      unregistrations++
+      listener = null
+    }
+    override fun check(result: (Result<UpdateOffer>) -> Unit) {
+      checks += result
+    }
+    override fun complete(result: (Result<Unit>) -> Unit) {
+      completions += result
+    }
+    fun answer(index: Int, offer: UpdateOffer) {
+      checks[index](Result.success(offer))
+    }
+  }
+}

--- a/docs/play-in-app-updates.md
+++ b/docs/play-in-app-updates.md
@@ -1,0 +1,59 @@
+# Google Play in-app updates
+
+Only the `play` Android flavor links `com.google.android.play:app-update`. The
+`foss` flavor provides an empty `StoreUpdatePrompt`; Desktop is unchanged.
+
+## Behavior
+
+- Check availability when the app resumes. Missing Play Store, an ineligible
+  installation/account, or an unsuccessful background check does not block usage.
+- Show a non-modal banner above the tabs when a flexible update is available.
+  Only tapping **Update** opens Google's consent flow. No automatic modal competes
+  with ad consent, rewarded ads, file selection or navigation.
+- Fetch fresh update information for each attempt; Play's consent token is
+  single-use. Canceling leaves the app usable. **Later** suppresses availability
+  prompts for the current Activity session (not a persisted opt-out).
+- Play downloads in the background. When downloaded, offer **Restart** and
+  **Later**. Only an explicit Restart/installation Retry calls `completeUpdate`;
+  there are no forced or immediate updates.
+- Recheck downloaded status on foreground entry, including after recreation or
+  a download that finished while the app was away. Dismissing a downloaded prompt
+  defers it until the next foreground entry.
+- Register the install listener while resumed and remove it on pause/disposal.
+  Generation/revision guards reject obsolete callbacks. Start/install failures
+  are dismissible and retryable.
+
+## Automated checks
+
+```sh
+./gradlew spotlessCheck :androidApp:testPlayDebugUnitTest \
+  :androidApp:assembleFossDebug :androidApp:assemblePlayDebug \
+  :shared:desktopTest :desktopApp:compileKotlin
+```
+
+The Play unit suite tests the real controller with a fake client, including
+explicit consent/restart, listener cleanup, downloaded recovery, stale callbacks,
+retry with new information and failure/cancellation. It does **not** prove the
+Google Play service, download or package replacement works on a device.
+
+## Play acceptance before rollout
+
+Use a Play test track or [internal app sharing][test]. You need:
+
+1. A test account that owns the app through Google Play, and an installed version
+   containing this integration.
+2. A newer eligible version with a **higher versionCode**, matching application ID
+   and signing identity. A locally sideloaded debug APK alone is not sufficient.
+3. For internal app sharing, open the newer build's sharing link but do not install
+   it from that Play page; return to the installed app.
+4. Exercise Update → cancel, Update → accept/download, background/foreground and
+   recreation during download, Later → resume after download, and Restart.
+5. Verify the new version is installed, and check unavailable/offline behavior.
+
+This integration does not change version codes, upload builds, or publish a
+release. Update priority/immediate-update policy is intentionally not configured.
+
+[guide]: https://developer.android.com/guide/playcore/in-app-updates/kotlin-java
+[test]: https://developer.android.com/guide/playcore/in-app-updates/test
+
+Implementation follows the [official Kotlin/Java guide][guide].

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,6 +30,7 @@ molecule-runtime = { module = "app.cash.molecule:molecule-runtime", version = "2
 accompanist-permissions = { module = "com.google.accompanist:accompanist-permissions", version = "0.37.3" }
 okio = { module = "com.squareup.okio:okio", version = "3.18.2" }
 
+play-app-update = { module = "com.google.android.play:app-update", version = "2.1.0" }
 play-services-ads = { module = "com.google.android.gms:play-services-ads", version = "25.4.0" }
 user-messaging-platform = { module = "com.google.android.ump:user-messaging-platform", version = "4.0.0" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version = "1.9.0" }


### PR DESCRIPTION
## Summary
- Add Google Play flexible in-app updates to the `play` flavor only, with a no-op FOSS entry and no shared/Desktop dependency changes.
- Offer a non-modal Update banner; open Play consent only on an explicit tap. Download in the background and request explicit Restart before installation.
- Recover downloaded updates on foreground entry; support Later, cancellation and retry. Guard stale callbacks, queued double taps and canceled pending checks; release listeners on pause/disposal.
- Add 18 controller regression tests, run them in CI, and document Play acceptance prerequisites.

## Verification
- `spotlessCheck`
- `:androidApp:testPlayDebugUnitTest`: 18 passing
- `:shared:desktopTest`: 79 passing
- Both Android debug builds and Desktop compilation
- Final APK DEX scan: app-update, Ads and UMP absent from FOSS and present in Play
- `git diff --check`

## Limits / scope
- Real Play consent/download/package replacement still requires an eligible Play installation/account and a higher-version build via internal sharing or a test track. Local fake-client tests do not substitute for this acceptance; see `docs/play-in-app-updates.md`.
- No forced/immediate updates, version bump, signing change, release, upload or device installation.
- Local design files and build evidence under `.planning/` are not included.
